### PR TITLE
Daemon: Query hostname and aliases for host entries

### DIFF
--- a/daemon/scripts/flecs-update-hosts.sh
+++ b/daemon/scripts/flecs-update-hosts.sh
@@ -20,17 +20,36 @@ fi
 
 (echo "init" && docker events --filter 'type=network' --filter 'event=connect' --filter 'event=disconnect' --filter 'network=flecs') | \
 while read line; do
+	# delete existing FLECS block from /etc/hosts
 	sed -i '/### BEGIN FLECS ###/,/### END FLECS ###/d' /etc/hosts
+
+	# create a new FLECS block in /etc/hosts
 	echo "### BEGIN FLECS ###" >>/etc/hosts
+
+	# print all containers' IPv4 address and name on the flecs network, separated by '#'
+	# as IPv4 addresses contain their according subnet, filter them out via sed: 172.21.0.2/16 -> 172.21.0.2
+	# results in a list such as:
+	# 172.21.0.2#flecs-abcd1234
+	# 172.21.0.3#flecs-0123abcd
 	ENTRIES=`docker network inspect -f '{{range.Containers}}{{.IPv4Address}}#{{println .Name}}{{end}}' flecs | sed -E 's,/[0-9]{2},,g'`
 	for i in ${ENTRIES}; do
+		# split each entry into IP...
 		IP=`echo ${i} | cut -f1 -d '#'`
+
+		# ...and container name
 		CONTAINER=`echo ${i} | cut -f2 -d '#'`
-		ALIASES=`docker inspect -f '{{.NetworkSettings.Networks.flecs.Aliases}}' ${CONTAINER} | grep -oP '(?<=\[).*(?=\])'`;
+
+		# collect aliases: older versions of Docker do not contain a container's hostname in the network aliases,
+		# so build an array consisting of container name, hostname, all network aliases...
+		ALIASES=(`echo ${CONTAINER}` `docker inspect -f '{{.Config.Hostname}}' ${CONTAINER}` `docker inspect -f '{{.NetworkSettings.Networks.flecs.Aliases}}' ${CONTAINER} | grep -oP '(?<=\[).*(?=\])'`);
+
+		# ...and filter out duplicates with sort
+		ALIASES=`echo ${ALIASES[*]} | tr ' ' '\n' | sort -u | tr '\n' ' '`
+
 		for j in ${ALIASES}; do
+			# create a hosts entry for each alias with the container's IP
 			echo "${IP} ${j}" >>/etc/hosts
 		done
-		echo "${IP} ${CONTAINER}" >>/etc/hosts
 	done
 	echo "### END FLECS ###" >>/etc/hosts
 done


### PR DESCRIPTION
Older versions of Docker do not list a container's hostname in its
network aliases. Therefore the update-hosts script should query
hostname and network aliases separately and combine then into
an array of unique hostnames