### PR TITLE
Services: Fix VM shutdown issue

### DIFF
--- a/daemon/pkg/debian/etc/systemd/system/flecs.service
+++ b/daemon/pkg/debian/etc/systemd/system/flecs.service
@@ -4,7 +4,10 @@ After=network-online.target
 Wants=network-online.target
 After=docker.service
 Requires=docker.service
+After=flecs-updater.service
 Wants=flecs-updater.service
+After=containerd.service
+Wants=containerd.service
 
 [Service]
 Type=exec

--- a/updater/pkg/debian/etc/systemd/system/flecs-updater.service
+++ b/updater/pkg/debian/etc/systemd/system/flecs-updater.service
@@ -4,6 +4,8 @@ After=network-online.target
 Wants=network-online.target
 After=docker.service
 Requires=docker.service
+After=containerd.service
+Wants=containerd.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
The beta VM (as well as all more recent Debian versions) blocks
on shutdown, "waiting for containerd-shim". By making the webapp
optionally depend on containerd.service, this issue is solved
while maintaining compatibility with older Debian versions where
this service does not exist.