### PR TITLE
Daemon: Installation bugfix

### DIFF
--- a/daemon/pkg/debian/DEBIAN/postinst
+++ b/daemon/pkg/debian/DEBIAN/postinst
@@ -4,7 +4,7 @@ PATH=/sbin:/bin:/usr/sbin:/usr/bin
 
 case "$1" in
   *)
-    docker network create --subnet 172.21.0.0/16 --gateway 172.21.0.1 flecs
+    docker network create --subnet 172.21.0.0/16 --gateway 172.21.0.1 flecs 2>/dev/null || true
     systemctl enable --now ##PACKAGE##
     ;;
 esac


### PR DESCRIPTION
Do not fail installation (remain in half-conf) when Docker
network flecs already exists. This is not an error condition
and should not lead to any issues with the installed package.