### PR TITLE
daemon: allow loading app manifests from string

### DIFF
--- a/daemon/CMakeLists.txt
+++ b/daemon/CMakeLists.txt
@@ -61,6 +61,7 @@ target_include_directories(FLECS.daemon PRIVATE
 target_link_libraries(FLECS.daemon PRIVATE
     FLECS.daemon.api
     FLECS.daemon.api.endpoints
+    FLECS.daemon.app
     FLECS.daemon.modules.app_manager
     FLECS.daemon.modules.data_layer
     FLECS.daemon.modules.factory

--- a/daemon/app/CMakeLists.txt
+++ b/daemon/app/CMakeLists.txt
@@ -32,11 +32,14 @@ target_include_directories(
     FLECS.daemon.app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-target_link_libraries(FLECS.daemon.app
+target_link_libraries(FLECS.daemon.app PUBLIC
+    FLECS.external.yaml-cpp
+)
+
+target_link_libraries(FLECS.daemon.app PRIVATE
     FLECS.daemon.app.conffile
     FLECS.daemon.app.env_var
     FLECS.daemon.app.port_range
-    FLECS.external.yaml-cpp
 )
 
 add_subdirectory(test)

--- a/daemon/app/app.h
+++ b/daemon/app/app.h
@@ -15,7 +15,10 @@
 #ifndef C8B89989_19D1_40AE_B788_DD80AE214500
 #define C8B89989_19D1_40AE_B788_DD80AE214500
 
+#include <yaml-cpp/yaml.h>
+
 #include <algorithm>
+#include <filesystem>
 #include <map>
 #include <set>
 #include <vector>
@@ -40,7 +43,9 @@ public:
     using args_t = std::vector<std::string>;
 
     app_t() noexcept;
-    explicit app_t(const std::string& manifest);
+
+    static app_t from_file(const std::filesystem::path& path);
+    static app_t from_string(const std::string& yaml);
 
     auto yaml_loaded() const noexcept { return _yaml_loaded; }
 
@@ -113,6 +118,8 @@ public:
     void desired(app_status_e desired) noexcept { _desired = desired; }
 
 private:
+    void load_yaml(const YAML::Node& yaml);
+
     bool _yaml_loaded;
 
     std::string _name;

--- a/daemon/app/test/test_app.cpp
+++ b/daemon/app/test/test_app.cpp
@@ -57,7 +57,7 @@ TEST(daemon_app, minimal_app)
 {
     auto manifest = manifest_writer_t{"minimal_app.yml", manifest_header()};
 
-    auto app = FLECS::app_t{manifest.filename()};
+    auto app = FLECS::app_t::from_file(manifest.filename());
 
     ASSERT_TRUE(app.yaml_loaded());
     ASSERT_EQ(app.name(), g_app);
@@ -71,7 +71,7 @@ TEST(daemon_app, empty_app)
 {
     auto manifest = manifest_writer_t{"empty_app.yml", std::string{}};
 
-    auto app = FLECS::app_t{manifest.filename()};
+    auto app = FLECS::app_t::from_file(manifest.filename());
 
     ASSERT_FALSE(app.yaml_loaded());
 }
@@ -102,9 +102,7 @@ TEST(daemon_app, complex_app)
     yaml.append("hostname: flecs-unit-test\n");
     yaml.append("interactive: true\n");
 
-    auto manifest = manifest_writer_t{"complex_app.yml", yaml};
-
-    auto app = FLECS::app_t{manifest.filename()};
+    auto app = FLECS::app_t::from_string(yaml);
 
     ASSERT_TRUE(app.yaml_loaded());
     ASSERT_EQ(app.description(), "FLECS Test application");
@@ -132,7 +130,7 @@ TEST(daemon_app, invalid_apps)
 
         auto manifest = manifest_writer_t{"invalid_app.yml", yaml};
 
-        auto app = FLECS::app_t{manifest.filename()};
+        auto app = FLECS::app_t::from_file(manifest.filename());
         ASSERT_FALSE(app.yaml_loaded());
         ASSERT_EQ(app.name(), "");
     }

--- a/daemon/modules/app_manager/CMakeLists.txt
+++ b/daemon/modules/app_manager/CMakeLists.txt
@@ -30,5 +30,5 @@ flecs_add_module(
         src/private/instance_stop.cpp
     ADDITIONAL_HEADERS private/app_manager_private.h
     LIBS_PUBLIC FLECS.daemon.db
-    LIBS_PRIVATE FLECS.util.json FLECS.external.cpr
+    LIBS_PRIVATE FLECS.util.json FLECS.external.cpr FLECS.daemon.app
 )

--- a/daemon/modules/app_manager/src/private/app_install.cpp
+++ b/daemon/modules/app_manager/src/private/app_install.cpp
@@ -127,7 +127,7 @@ http_status_e module_app_manager_private_t::do_install(
     const auto desired = INSTALLED;
 
     // Step 1: Load app manifest
-    const auto app = app_t{manifest};
+    const auto app = app_t::from_file(manifest);
     if (!app.yaml_loaded())
     {
         response["additionalInfo"] = "Could not open app manifest " + manifest;

--- a/daemon/modules/app_manager/src/private/app_manager_private.cpp
+++ b/daemon/modules/app_manager/src/private/app_manager_private.cpp
@@ -127,7 +127,7 @@ void module_app_manager_private_t::do_init()
         {
             std::fprintf(stdout, "Installing system app %s\n", system_apps[i]);
             download_manifest(system_apps[i], FLECS_VERSION);
-            auto app = app_t{build_manifest_path(system_apps[i], FLECS_VERSION)};
+            auto app = app_t::from_file(build_manifest_path(system_apps[i], FLECS_VERSION));
             if (app.yaml_loaded())
             {
                 auto response = Json::Value{};

--- a/daemon/modules/app_manager/src/private/app_sideload.cpp
+++ b/daemon/modules/app_manager/src/private/app_sideload.cpp
@@ -25,7 +25,7 @@ http_status_e module_app_manager_private_t::do_sideload(
     const std::string& manifest_path, const std::string& license_key, Json::Value& response)
 {
     // Step 1: Parse transferred manifest
-    auto app = app_t{manifest_path};
+    auto app = app_t::from_file(manifest_path);
     if (!app.yaml_loaded())
     {
         response["additionalInfo"] = "Could not open manifest " + manifest_path;

--- a/daemon/modules/app_manager/src/private/app_uninstall.cpp
+++ b/daemon/modules/app_manager/src/private/app_uninstall.cpp
@@ -39,7 +39,7 @@ http_status_e module_app_manager_private_t::do_uninstall(
     // Step 2: Load app manifest
     const auto path = build_manifest_path(app_name, version);
 
-    auto app = app_t{path};
+    auto app = app_t::from_file(path);
     if (!app.yaml_loaded())
     {
         // Manifest missing or invalid - persist removal of app into db

--- a/daemon/modules/app_manager/src/private/instance_create.cpp
+++ b/daemon/modules/app_manager/src/private/instance_create.cpp
@@ -46,7 +46,7 @@ http_status_e module_app_manager_private_t::do_create_instance(
 
     // Step 2: Load app manifest
     const auto path = build_manifest_path(app_name, version);
-    app_t app{path};
+    auto app = app_t::from_file(path);
     if (!app.yaml_loaded())
     {
         response["additionalInfo"] = "Could not open manifest " + path;

--- a/daemon/modules/app_manager/src/private/instance_delete.cpp
+++ b/daemon/modules/app_manager/src/private/instance_delete.cpp
@@ -72,7 +72,7 @@ http_status_e module_app_manager_private_t::do_delete_instance(
 
     // Step 5: Attempt to load app manifest
     const auto path = build_manifest_path(instance.app, instance.version);
-    app_t app{path};
+    auto app = app_t::from_file(path);
     if (!app.yaml_loaded())
     {
         std::fprintf(

--- a/daemon/modules/app_manager/src/private/instance_details.cpp
+++ b/daemon/modules/app_manager/src/private/instance_details.cpp
@@ -37,7 +37,7 @@ http_status_e module_app_manager_private_t::do_instance_details(const std::strin
     // Step 2: Obtain instance and corresponsing app
     const auto instance = _app_db.query_instance({id}).value();
     const auto manifest_path = build_manifest_path(instance.app, instance.version);
-    const auto app = app_t{manifest_path};
+    const auto app = app_t::from_file(manifest_path);
 
     // Build response
     response["app"] = instance.app;

--- a/daemon/modules/app_manager/src/private/instance_start.cpp
+++ b/daemon/modules/app_manager/src/private/instance_start.cpp
@@ -75,7 +75,7 @@ http_status_e module_app_manager_private_t::do_start_instance(
 
     // Step 4: Load app manifest
     const auto path = build_manifest_path(instance.app, instance.version);
-    app_t app{path};
+    auto app = app_t::from_file(path);
     if (!app.yaml_loaded())
     {
         response["additionalInfo"] = "Could not open manifest " + path;


### PR DESCRIPTION
Currently, app sideloading requires an app manifest to be present
in the local filesystem. This means that each manifest has to be
written into a temporary file first, and then again copied to the
local manifest store. Besides possible security implications (i.e.
blindly writing any content to the local, temporary filesystem),
this produces avoidable overhead, especially when sideloading
from the WebApp.

This patch allows loading an app manifest directly from a string
instead, which gives the opportunity to validate an app manifest
YAML before writing it to disk.