### PR TITLE
daemon: provide API to sideload via manifest string

### DIFF
--- a/daemon/api/src/api.cpp
+++ b/daemon/api/src/api.cpp
@@ -98,7 +98,7 @@ http_status_e flecs_api_t::process(socket_t& conn_socket)
     }
 
     auto args = Json::Value{};
-    if (llhttp_ext.method == HTTP_POST)
+    if (llhttp_ext.method == HTTP_POST || llhttp_ext.method == HTTP_PUT)
     {
         const auto success = _json_reader->parse(
             llhttp_ext._body.c_str(),
@@ -109,22 +109,6 @@ http_status_e flecs_api_t::process(socket_t& conn_socket)
         {
             return http_status_e::BadRequest;
         }
-    }
-    else if (llhttp_ext.method == HTTP_PUT)
-    {
-        char tmp[] = "/tmp/flecs-XXXXXX";
-        int fd = mkstemp(tmp);
-        if (fd < -1)
-        {
-            return http_status_e::InternalServerError;
-        }
-        const auto res = write(fd, llhttp_ext._body.c_str(), llhttp_ext._body.length());
-        close(fd);
-        if (res != static_cast<ssize_t>(llhttp_ext._body.length()))
-        {
-            return http_status_e::InternalServerError;
-        }
-        args["path"] = tmp;
     }
     else if (llhttp_ext.method != HTTP_GET)
     {

--- a/daemon/modules/app_manager/private/app_manager_private.h
+++ b/daemon/modules/app_manager/private/app_manager_private.h
@@ -15,6 +15,7 @@
 #ifndef A26C3D22_DE7E_4EF2_BA44_CB50A45E8C9B
 #define A26C3D22_DE7E_4EF2_BA44_CB50A45E8C9B
 
+#include <filesystem>
 #include <string>
 
 #include "db/app_db.h"
@@ -84,7 +85,22 @@ public:
      * @return FLECS_IOW: Error writing manifest to FLECS application directory
      * @return Any error code returned by overloaded @sa do_install(const std::string&, const std::string&)
      */
-    http_status_e do_sideload(const std::string& manifest_path, const std::string& license_key, Json::Value& response);
+    http_status_e do_sideload(const std::string& yaml, const std::string& license_key, Json::Value& response);
+
+    /*! @brief Sideloads an app from its YAML manifest
+     *
+     * Copies the transferred app manifest and forwards to manifest installation
+     *
+     * @param[in] manifest_path Path to a YAML manifest file
+     *
+     * @return error code
+     * @return FLECS_OK: No error occurred
+     * @return FLECS_IOR: Error reading from manifest
+     * @return FLECS_IOW: Error writing manifest to FLECS application directory
+     * @return Any error code returned by overloaded @sa do_install(const std::string&, const std::string&)
+     */
+    http_status_e do_sideload(
+        const std::filesystem::path& manifest_path, const std::string& license_key, Json::Value& response);
 
     /*! @brief Uninstalls an application
      *

--- a/daemon/modules/app_manager/src/app_manager.cpp
+++ b/daemon/modules/app_manager/src/app_manager.cpp
@@ -61,9 +61,9 @@ http_status_e module_app_manager_t::install(const Json::Value& args, Json::Value
 
 http_status_e module_app_manager_t::sideload(const Json::Value& args, Json::Value& response)
 {
-    REQUIRED_JSON_VALUE(args, path);
+    REQUIRED_JSON_VALUE(args, appYaml);
     OPTIONAL_JSON_VALUE(args, licenseKey);
-    return _impl->do_sideload(path, licenseKey, response);
+    return _impl->do_sideload(appYaml, licenseKey, response);
 }
 
 http_status_e module_app_manager_t::uninstall(const Json::Value& args, Json::Value& response)

--- a/daemon/modules/app_manager/src/private/app_sideload.cpp
+++ b/daemon/modules/app_manager/src/private/app_sideload.cpp
@@ -14,6 +14,7 @@
 
 #include <cstdio>
 #include <filesystem>
+#include <fstream>
 
 #include "app/app.h"
 #include "private/app_manager_private.h"
@@ -22,13 +23,39 @@ namespace FLECS {
 namespace Private {
 
 http_status_e module_app_manager_private_t::do_sideload(
-    const std::string& manifest_path, const std::string& license_key, Json::Value& response)
+    const std::string& yaml, const std::string& license_key, Json::Value& response)
+{
+    // Step 1: Parse transferred manifest
+    auto app = app_t::from_string(yaml);
+    if (!app.yaml_loaded())
+    {
+        response["additionalInfo"] = "Could not parse manifest";
+        return http_status_e::InternalServerError;
+    }
+
+    // Step 2: Copy manifest to local storage
+    const auto manifest_path = build_manifest_path(app.name(), app.version());
+
+    auto file = std::fstream{manifest_path, std::fstream::out};
+    file << yaml;
+    if (!file)
+    {
+        response["additionalInfo"] = "Could not place manifest in " + manifest_path;
+        return http_status_e::InternalServerError;
+    }
+
+    // Step 3: Forward to manifest installation
+    return do_install(manifest_path, license_key, response);
+}
+
+http_status_e module_app_manager_private_t::do_sideload(
+    const std::filesystem::path& manifest_path, const std::string& license_key, Json::Value& response)
 {
     // Step 1: Parse transferred manifest
     auto app = app_t::from_file(manifest_path);
     if (!app.yaml_loaded())
     {
-        response["additionalInfo"] = "Could not open manifest " + manifest_path;
+        response["additionalInfo"] = "Could not open manifest " + manifest_path.string();
         return http_status_e::InternalServerError;
     }
 


### PR DESCRIPTION
Extend the sideloading API to not only accept paths in the local
filesystem, but a manifest YAML as string as well.