### PR TITLE
daemon: bugfix in sideloading + gtest

### DIFF
--- a/daemon/api/lib/test/test_api_lib.cpp
+++ b/daemon/api/lib/test/test_api_lib.cpp
@@ -218,7 +218,7 @@ TEST(api_lib, app_uninstall)
     ASSERT_EQ(response["version"], version);
 }
 
-TEST(api_lib, app_sideload_success)
+TEST(api_lib, app_sideload_file_success)
 {
     auto lib = FLECS::libflecs_t{};
     lib.connect("localhost", TEST_PORT);
@@ -230,6 +230,23 @@ TEST(api_lib, app_sideload_success)
     fclose(manifest_file);
     const auto res = lib.sideload_app_from_file(filename);
     std::filesystem::remove(filename);
+
+    const auto response = parse_json(lib.json_response());
+
+    ASSERT_EQ(res, 0);
+    ASSERT_EQ(response["endpoint"], "/app/sideload");
+    ASSERT_EQ(response["appYaml"], app_manifest);
+}
+
+TEST(api_lib, app_sideload_string_success)
+{
+    auto lib = FLECS::libflecs_t{};
+    lib.connect("localhost", TEST_PORT);
+    // const auto app_manifest = "app: \"tech.flecs.sideloaded-app\"\r\ntitle: \"Sideloaded FLECS app\"\r\n";
+    const auto app_manifest =
+        "\"app\":\"ch.inasoft.sql4automation\",\"title\":\"SQL4AUTOMATION\",\"version\":\"v4.0.0.6\"";
+
+    const auto res = lib.sideload_app_from_yaml(app_manifest);
 
     const auto response = parse_json(lib.json_response());
 

--- a/daemon/modules/app_manager/src/private/app_sideload.cpp
+++ b/daemon/modules/app_manager/src/private/app_sideload.cpp
@@ -36,12 +36,14 @@ http_status_e module_app_manager_private_t::do_sideload(
     // Step 2: Copy manifest to local storage
     const auto manifest_path = build_manifest_path(app.name(), app.version());
 
-    auto file = std::fstream{manifest_path, std::fstream::out};
-    file << yaml;
-    if (!file)
     {
-        response["additionalInfo"] = "Could not place manifest in " + manifest_path;
-        return http_status_e::InternalServerError;
+        auto file = std::fstream{manifest_path, std::fstream::out};
+        file << yaml;
+        if (!file)
+        {
+            response["additionalInfo"] = "Could not place manifest in " + manifest_path;
+            return http_status_e::InternalServerError;
+        }
     }
 
     // Step 3: Forward to manifest installation


### PR DESCRIPTION
When storing the app manifest, the file handle was kept open, which
led to an error in do_install as it has not been written back to
disk yet. Close the file handle after write to fix this.