### PR TITLE
daemon: allow force-removal of system apps

### DIFF
--- a/daemon/modules/app_manager/private/app_manager_private.h
+++ b/daemon/modules/app_manager/private/app_manager_private.h
@@ -114,7 +114,8 @@ public:
      * @return FLECS_DOCKER: Unsuccessful exit code from spawned Docker process
      * @return FLECS_IOW: Error deleting manifest from disk
      */
-    http_status_e do_uninstall(const std::string& app_name, const std::string& version, Json::Value& response);
+    http_status_e do_uninstall(
+        const std::string& app_name, const std::string& version, Json::Value& response, bool force = false);
 
     /*! @brief Creates a new instance of an installed app
      *

--- a/daemon/modules/app_manager/src/private/app_manager_private.cpp
+++ b/daemon/modules/app_manager/src/private/app_manager_private.cpp
@@ -135,7 +135,7 @@ void module_app_manager_private_t::do_init()
                     instance.version.c_str(),
                     instance.app.c_str());
                 auto response = Json::Value{};
-                do_uninstall(instance.app, instance.version, response);
+                do_uninstall(instance.app, instance.version, response, true);
             }
         }
     }

--- a/daemon/modules/app_manager/src/private/app_uninstall.cpp
+++ b/daemon/modules/app_manager/src/private/app_uninstall.cpp
@@ -23,7 +23,7 @@ namespace FLECS {
 namespace Private {
 
 http_status_e module_app_manager_private_t::do_uninstall(
-    const std::string& app_name, const std::string& version, Json::Value& response)
+    const std::string& app_name, const std::string& version, Json::Value& response, bool force)
 {
     response["additionalInfo"] = std::string{};
     response["app"] = app_name;
@@ -51,7 +51,7 @@ http_status_e module_app_manager_private_t::do_uninstall(
     }
 
     // Step 2a: Prevent removal of system apps
-    if (cxx20::contains(app.category(), "system"))
+    if (cxx20::contains(app.category(), "system") && !force)
     {
         response["additionalInfo"] = "Not removing system app " + app.name() + "(" + app.version() + ")";
         return http_status_e::InternalServerError;


### PR DESCRIPTION
On upgrading, installing newer versions of system apps might be
required. As removal of system apps was not possible in v1.0.0,
a new path is added to allow forcing the removal.