### PR TITLE
daemon: hard-code available system apps versions

### DIFF
--- a/apps/tech.flecs.mqtt-bridge/CMakeLists.txt
+++ b/apps/tech.flecs.mqtt-bridge/CMakeLists.txt
@@ -33,8 +33,9 @@ target_link_libraries(FLECS.apps.mqtt-bridge PRIVATE
 
 # configure Docker image
 set(DOCKER_IMAGE "tech.flecs.mqtt-bridge")
+set(APP_VERSION "v1.0.0-porpoise")
 
-set(DOCKER_TAG ${VERSION})
+set(DOCKER_TAG ${APP_VERSION})
 
 install(
     TARGETS FLECS.apps.mqtt-bridge

--- a/apps/tech.flecs.service-mesh/CMakeLists.txt
+++ b/apps/tech.flecs.service-mesh/CMakeLists.txt
@@ -16,8 +16,9 @@ project(FLECS.apps.service-mesh)
 
 # configure Docker image
 set(DOCKER_IMAGE "tech.flecs.service-mesh")
+set(APP_VERSION "v1.0.0-porpoise")
 
-set(DOCKER_TAG ${VERSION})
+set(DOCKER_TAG ${APP_VERSION})
 
 install(
     DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/assets

--- a/daemon/modules/app_manager/src/private/app_manager_private.cpp
+++ b/daemon/modules/app_manager/src/private/app_manager_private.cpp
@@ -116,6 +116,7 @@ void module_app_manager_private_t::do_init()
     // "install" system apps on first start
     constexpr auto system_apps = std::array<const char*, 2>{"tech.flecs.mqtt-bridge", "tech.flecs.service-mesh"};
     constexpr auto system_apps_desc = std::array<const char*, 2>{"FLECS MQTT Bridge", "FLECS Service Mesh"};
+    constexpr auto system_apps_versions = std::array<const char*, 2>{"v1.0.0-porpoise", "v1.0.0-porpoise"};
 
     for (size_t i = 0; i < system_apps.size(); ++i)
     {
@@ -127,7 +128,7 @@ void module_app_manager_private_t::do_init()
 
         for (const auto& instance : instances)
         {
-            if (instance.version != FLECS_VERSION)
+            if (instance.version != system_apps_versions[i])
             {
                 std::fprintf(
                     stdout,
@@ -142,21 +143,21 @@ void module_app_manager_private_t::do_init()
 
     for (size_t i = 0; i < system_apps.size(); ++i)
     {
-        const auto has_instance = !_app_db.instances(system_apps[i], FLECS_VERSION).empty();
+        const auto has_instance = !_app_db.instances(system_apps[i], system_apps_versions[i]).empty();
         const auto instance_ready =
-            has_instance ? (_app_db.instances(system_apps[i], FLECS_VERSION)[0].status == CREATED) : false;
+            has_instance ? (_app_db.instances(system_apps[i], system_apps_versions[i])[0].status == CREATED) : false;
 
         if (!instance_ready)
         {
             std::fprintf(stdout, "Installing system app %s\n", system_apps[i]);
-            download_manifest(system_apps[i], FLECS_VERSION);
-            auto app = app_t::from_file(build_manifest_path(system_apps[i], FLECS_VERSION));
+            download_manifest(system_apps[i], system_apps_versions[i]);
+            auto app = app_t::from_file(build_manifest_path(system_apps[i], system_apps_versions[i]));
             if (app.yaml_loaded())
             {
                 auto response = Json::Value{};
                 _app_db.insert_app({{app.name(), app.version()}, {INSTALLED, INSTALLED, app.category(), 0, "", ""}});
                 do_create_instance(app.name(), app.version(), system_apps_desc[i], response);
-                const auto app_instances = _app_db.instances(system_apps[i], FLECS_VERSION);
+                const auto app_instances = _app_db.instances(system_apps[i], system_apps_versions[i]);
                 if (!app_instances.empty())
                 {
                     auto instance = *app_instances.begin();


### PR DESCRIPTION
Upon new releases, a new version of system apps may or may not
be available. For now, hard-code the most recent version until
a more generic solution is in place, such as querying the most
recent version from the marketplace or determining it from the
provided Docker images.