### PR TITLE
daemon: fix potential sigsegv network adapter query

### DIFF
--- a/daemon/modules/system/src/system.cpp
+++ b/daemon/modules/system/src/system.cpp
@@ -63,6 +63,11 @@ auto module_system_t::get_network_adapters() const -> std::map<std::string, neti
 
     while (ifa)
     {
+        if (!ifa->ifa_addr)
+        {
+            ifa = ifa->ifa_next;
+            continue;
+        }
         switch (ifa->ifa_addr->sa_family)
         {
             case AF_PACKET: {


### PR DESCRIPTION
For some interface types (such as CAN interfaces),
ifa_addr might be NULL, resulting in a SIGSEGV when
blindly accessing it.