### PR TITLE
daemon: implement GET methods of jobs API

### DIFF
--- a/daemon/modules/jobs/CMakeLists.txt
+++ b/daemon/modules/jobs/CMakeLists.txt
@@ -14,8 +14,8 @@
 
 flecs_add_module(
     MODULE_NAME jobs
-    ADDITIONAL_HEADERS impl/jobs_impl.h job_id.h job_progress.h
-    ADDITIONAL_SOURCES src/impl/jobs_impl.cpp src/job_progress.cpp
+    ADDITIONAL_HEADERS impl/jobs_impl.h job_id.h job_progress.h job_status.h
+    ADDITIONAL_SOURCES src/impl/jobs_impl.cpp src/job_progress.cpp src/job_status.cpp
 )
 
 add_subdirectory(test)

--- a/daemon/modules/jobs/impl/jobs_impl.h
+++ b/daemon/modules/jobs/impl/jobs_impl.h
@@ -44,6 +44,9 @@ private:
     auto do_deinit() //
         -> void;
 
+    auto do_list_jobs(job_id_t job_id) const //
+        -> crow::response;
+
     auto do_append(job_t job) //
         -> job_id_t;
 

--- a/daemon/modules/jobs/job_progress.h
+++ b/daemon/modules/jobs/job_progress.h
@@ -19,12 +19,24 @@
 #include <string>
 
 #include "job_id.h"
+#include "job_status.h"
+#include "util/json/json.h"
 
 namespace FLECS {
 
 class job_progress_t
 {
 public:
+    job_progress_t()
+        : _job_id{}
+        , _status{}
+        , _desc{}
+        , _num_steps{}
+        , _current_step{}
+        , _result{}
+        , _mutex{}
+    {}
+
     struct current_step_t
     {
         std::string _desc;          /** current step description*/
@@ -33,12 +45,26 @@ public:
         std::uint32_t _units_total; /** total units to process */
         std::uint32_t _units_done;  /** processed units so far*/
         std::uint32_t _rate;        /** processing rate in units per second*/
+
+        current_step_t()
+            : _desc{}
+            , _num{}
+            , _unit{}
+            , _units_total{}
+            , _units_done{}
+            , _rate{}
+        {}
     };
 
     struct result_t
     {
         std::int32_t code;
         std::string message;
+
+        result_t()
+            : code{}
+            , message{}
+        {}
     };
 
     explicit job_progress_t(job_id_t job_id);
@@ -50,11 +76,17 @@ public:
         -> std::unique_lock<std::mutex>;
 
     auto status() const //
-        -> std::uint32_t;
+        -> job_status_e;
     auto desc() const noexcept //
         -> const std::string&;
     auto num_steps() const noexcept //
         -> std::int16_t;
+    auto status(job_status_e status) noexcept //
+        -> void;
+    auto desc(std::string desc) noexcept //
+        -> void;
+    auto num_steps(std::int16_t num_steps) noexcept //
+        -> void;
 
     auto current_step() noexcept //
         -> current_step_t&;
@@ -67,9 +99,12 @@ public:
         -> const result_t&;
 
 private:
+    friend auto to_json(json_t& j, const job_progress_t& progress) //
+        -> void;
+
     job_id_t _job_id; /** unique job id */
 
-    std::uint32_t _status;   /** @todo job status - replace by enum */
+    job_status_e _status;    /** @todo job status - replace by enum */
     std::string _desc;       /** job description (e.g. "Install app xyz (123) ")*/
     std::int16_t _num_steps; /** total number of steps  */
 

--- a/daemon/modules/jobs/job_status.h
+++ b/daemon/modules/jobs/job_status.h
@@ -1,0 +1,34 @@
+// Copyright 2021-2023 FLECS Technologies GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <string_view>
+
+namespace FLECS {
+
+enum class job_status_e : std::uint32_t {
+    Pending,
+    Queued,
+    Running,
+    Cancelled,
+    Successful,
+    Failed,
+};
+
+auto to_string(job_status_e job_status) //
+    -> std::string_view;
+
+} // namespace FLECS

--- a/daemon/modules/jobs/jobs.h
+++ b/daemon/modules/jobs/jobs.h
@@ -49,6 +49,9 @@ public:
     auto append(job_t job) //
         -> job_id_t;
 
+    auto list_jobs(job_id_t job_id) const //
+        -> crow::response;
+
 protected:
     module_jobs_t();
 

--- a/daemon/modules/jobs/src/job_progress.cpp
+++ b/daemon/modules/jobs/src/job_progress.cpp
@@ -33,7 +33,7 @@ auto job_progress_t::lock() const //
 }
 
 auto job_progress_t::status() const //
-    -> std::uint32_t
+    -> job_status_e
 {
     return _status;
 }
@@ -46,6 +46,24 @@ auto job_progress_t::num_steps() const noexcept //
     -> std::int16_t
 {
     return _num_steps;
+}
+
+auto job_progress_t::status(job_status_e status) noexcept //
+    -> void
+{
+    _status = std::move(status);
+}
+
+auto job_progress_t::desc(std::string desc) noexcept //
+    -> void
+{
+    _desc = std::move(desc);
+}
+
+auto job_progress_t::num_steps(std::int16_t num_steps) noexcept //
+    -> void
+{
+    _num_steps = std::move(num_steps);
 }
 
 auto job_progress_t::current_step() noexcept //
@@ -68,6 +86,28 @@ auto job_progress_t::result() const noexcept //
     -> const result_t&
 {
     return _result;
+}
+
+auto to_json(json_t& j, const job_progress_t& progress) //
+    -> void
+{
+    j = json_t{};
+
+    auto lock = progress.lock();
+    j["id"] = progress._job_id;
+    j["status"] = to_string(progress._status);
+    j["description"] = progress._desc;
+    j["numSteps"] = progress._num_steps;
+    j["currentStep"] = json_t::object();
+    j["currentStep"]["description"] = progress._current_step._desc;
+    j["currentStep"]["num"] = progress._current_step._num;
+    j["currentStep"]["unit"] = progress._current_step._unit;
+    j["currentStep"]["unitsTotal"] = progress._current_step._units_total;
+    j["currentStep"]["unitsDone"] = progress._current_step._units_done;
+    j["currentStep"]["rate"] = progress._current_step._rate;
+    j["result"] = json_t::object();
+    j["result"]["code"] = progress._result.code;
+    j["result"]["message"] = progress._result.message;
 }
 
 auto operator<(const job_progress_t& lhs, const job_progress_t& rhs) //

--- a/daemon/modules/jobs/src/job_status.cpp
+++ b/daemon/modules/jobs/src/job_status.cpp
@@ -1,0 +1,45 @@
+// Copyright 2021-2023 FLECS Technologies GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "job_status.h"
+
+#include <algorithm>
+#include <array>
+#include <tuple>
+
+namespace FLECS {
+
+auto to_string(job_status_e job_status) //
+    -> std::string_view
+{
+    constexpr auto strings = std::array<std::tuple<job_status_e, std::string_view>, 6>{{
+        {job_status_e::Pending, "pending"},
+        {job_status_e::Queued, "queued"},
+        {job_status_e::Running, "running"},
+        {job_status_e::Cancelled, "cancelled"},
+        {job_status_e::Successful, "successful"},
+        {job_status_e::Failed, "failed"},
+    }};
+
+    const auto it = std::find_if(
+        strings.cbegin(),
+        strings.cend(),
+        [&job_status](const std::tuple<job_status_e, std::string_view>& elem) {
+            return std::get<0>(elem) == job_status;
+        });
+
+    return it == strings.cend() ? "unknown" : std::get<1>(*it);
+}
+
+} // namespace FLECS

--- a/daemon/modules/jobs/src/jobs.cpp
+++ b/daemon/modules/jobs/src/jobs.cpp
@@ -32,6 +32,11 @@ module_jobs_t::~module_jobs_t() = default;
 auto module_jobs_t::do_init() //
     -> void
 {
+    FLECS_V2_ROUTE("/jobs").methods("GET"_method)([this]() { return list_jobs({}); });
+    FLECS_V2_ROUTE("/jobs/<uint>").methods("GET"_method)([this](std::uint32_t job_id) {
+        return list_jobs(job_id_t{job_id});
+    });
+
     _impl->do_init();
 }
 
@@ -45,6 +50,12 @@ auto module_jobs_t::append(job_t job) //
     -> job_id_t
 {
     return _impl->do_append(std::move(job));
+}
+
+auto module_jobs_t::list_jobs(job_id_t job_id) const //
+    -> crow::response
+{
+    return _impl->do_list_jobs(std::move(job_id));
 }
 
 } // namespace FLECS


### PR DESCRIPTION
Asynchronous operations each track their progress in a job_progress structure. Through a centralized API a list of all jobs as well as the progress of a single job should be retrievable.

This commit implements said /jobs and /jobs/{id} routes and adds improvements to the underlying structures, such as defined start values and automatically setting/resetting some status flags in the progress structure.