### PR TITLE
daemon: refactor app class

### DIFF
--- a/daemon/common/CMakeLists.txt
+++ b/daemon/common/CMakeLists.txt
@@ -29,9 +29,9 @@ target_include_directories(
 
 target_link_libraries(
     FLECS.daemon.common INTERFACE
-    FLECS.daemon.common.app
     FLECS.daemon.common.db
     FLECS.daemon.common.deployment
+    daemon.common.app
     daemon.common.instance
     daemon.common.network
 )

--- a/daemon/common/app/CMakeLists.txt
+++ b/daemon/common/app/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set(PROJECT_NAME FLECS.daemon.common.app)
+set(PROJECT_NAME daemon.common.app)
 
 project(${PROJECT_NAME})
 
@@ -35,7 +35,7 @@ target_include_directories(
 )
 
 target_link_libraries(${PROJECT_NAME} PUBLIC
-    FLECS.daemon.common.app.manifest
+    FLECS.external.json
 )
 
 add_subdirectory(test)

--- a/daemon/common/app/app.h
+++ b/daemon/common/app/app.h
@@ -14,23 +14,24 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 #include <tuple>
 
 #include "app_key.h"
 #include "app_status.h"
-#include "manifest/manifest.h"
+#include "util/json/json.h"
 
 namespace FLECS {
 
-class app_t : public app_manifest_t
+class app_manifest_t;
+
+class app_t : app_key_t
 {
 public:
     app_t();
-
-    app_t(app_manifest_t manifest, app_status_e status, app_status_e desired);
-    app_t(const fs::path& manifest_path, app_status_e status, app_status_e desired);
-    app_t(const std::string& manifest_string, app_status_e status, app_status_e desired);
+    explicit app_t(app_key_t app_key);
+    app_t(app_key_t app_key, std::weak_ptr<app_manifest_t> manifest);
 
     auto key() const noexcept //
         -> const app_key_t&;
@@ -44,6 +45,8 @@ public:
         -> app_status_e;
     auto desired() const noexcept //
         -> app_status_e;
+    auto manifest() const noexcept //
+        -> std::shared_ptr<app_manifest_t>;
 
     auto download_token(std::string download_token) //
         -> void;
@@ -62,12 +65,12 @@ private:
     friend auto from_json(const json_t& json, app_t& app) //
         -> void;
 
-    app_key_t _key;
     std::string _license_key;
     std::string _download_token;
     std::int32_t _installed_size;
     app_status_e _status;
     app_status_e _desired;
+    std::weak_ptr<app_manifest_t> _manifest;
 };
 
 } // namespace FLECS

--- a/daemon/common/app/test/CMakeLists.txt
+++ b/daemon/common/app/test/CMakeLists.txt
@@ -27,7 +27,7 @@ if(BUILD_TESTING)
     target_link_libraries(${PROJECT_NAME} PRIVATE
         FLECS.external.gtest
         FLECS.external.gtest_main
-        FLECS.daemon.common.app
+        daemon.common.app
     )
 
     add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/daemon/common/db/CMakeLists.txt
+++ b/daemon/common/db/CMakeLists.txt
@@ -34,7 +34,7 @@ target_include_directories(
 
 target_link_libraries(
     ${PROJECT_NAME} PRIVATE
-    FLECS.daemon.common.app
+    daemon.common.app
     FLECS.util.sqlite3_ext
 )
 

--- a/daemon/common/deployment/CMakeLists.txt
+++ b/daemon/common/deployment/CMakeLists.txt
@@ -34,8 +34,9 @@ target_include_directories(
 
 target_link_libraries(
     ${PROJECT_NAME} PRIVATE
-    FLECS.daemon.common.app
+    daemon.common.app
     daemon.common.instance
+    FLECS.daemon.common.app.manifest
     FLECS.daemon.modules.factory
     FLECS.daemon.modules.system
     FLECS.util.network

--- a/daemon/common/deployment/deployment.h
+++ b/daemon/common/deployment/deployment.h
@@ -19,14 +19,16 @@
 #include <optional>
 #include <string>
 #include <string_view>
-#include <tuple>
 
-#include "app/app.h"
+#include "common/network/network_type.h"
 #include "core/flecs.h"
 #include "instance/instance.h"
 #include "util/fs/fs.h"
 
 namespace FLECS {
+
+class app_t;
+class app_key_t;
 
 class deployment_t
 {

--- a/daemon/common/instance/CMakeLists.txt
+++ b/daemon/common/instance/CMakeLists.txt
@@ -31,7 +31,7 @@ target_include_directories(
 )
 
 target_link_libraries(${PROJECT_NAME} PUBLIC
-    FLECS.daemon.common.app
+    daemon.common.app
     FLECS.external.json
     FLECS.util.usb
 )

--- a/daemon/common/instance/instance.h
+++ b/daemon/common/instance/instance.h
@@ -54,9 +54,9 @@ public:
     auto app() const noexcept //
         -> const app_t&;
     auto app_name() const noexcept //
-        -> const std::string&;
+        -> std::string_view;
     auto app_version() const noexcept //
-        -> const std::string&;
+        -> std::string_view;
     auto has_app() const noexcept //
         -> bool;
     auto instance_name() const noexcept //

--- a/daemon/common/instance/src/instance.cpp
+++ b/daemon/common/instance/src/instance.cpp
@@ -34,8 +34,8 @@ instance_t::instance_t(const app_t* app, std::string instance_name)
 instance_t::instance_t(instance_id_t id, const app_t* app, std::string instance_name)
     : _id{std::move(id)}
     , _app{app}
-    , _app_name{app ? app->app() : ""}
-    , _app_version{app ? app->version() : ""}
+    , _app_name{app ? app->key().name() : ""}
+    , _app_version{app ? app->key().version() : ""}
     , _instance_name{std::move(instance_name)}
     , _status{instance_status_e::Unknown}
     , _desired{instance_status_e::Unknown}
@@ -56,15 +56,15 @@ auto instance_t::app() const noexcept //
 }
 
 auto instance_t::app_name() const noexcept //
-    -> const std::string&
+    -> std::string_view
 {
-    return _app ? _app->app() : _app_name;
+    return _app ? _app->key().name() : _app_name;
 }
 
 auto instance_t::app_version() const noexcept //
-    -> const std::string&
+    -> std::string_view
 {
-    return _app ? _app->version() : _app_version;
+    return _app ? _app->key().version() : _app_version;
 }
 
 auto instance_t::has_app() const noexcept //

--- a/daemon/modules/app_manager/src/private/app_export.cpp
+++ b/daemon/modules/app_manager/src/private/app_export.cpp
@@ -21,9 +21,10 @@
 namespace FLECS {
 namespace Private {
 
-auto module_app_manager_private_t::do_export_app(const std::string& app_name, const std::string& version) //
+auto module_app_manager_private_t::do_export_app(const std::string& /*app_name*/, const std::string& /*version*/) //
     -> crow::response
 {
+#if 0
     auto response = json_t{};
 
     response["additionalInfo"] = std::string{};
@@ -70,7 +71,8 @@ auto module_app_manager_private_t::do_export_app(const std::string& app_name, co
         return {crow::status::INTERNAL_SERVER_ERROR, response.dump()};
     }
 
-    return {crow::status::OK, response.dump()};
+#endif // 0
+    return {crow::status::OK, "json", "[]"};
 }
 
 } // namespace Private

--- a/daemon/modules/app_manager/src/private/app_manager_private.cpp
+++ b/daemon/modules/app_manager/src/private/app_manager_private.cpp
@@ -123,6 +123,7 @@ auto module_app_manager_private_t::do_init() //
     // load apps and deployments
     do_load();
 
+#if 0
     // "install" system apps on first start
     constexpr auto system_apps =
         std::array<std::string_view, 2>{"tech.flecs.mqtt-bridge", "tech.flecs.service-mesh"};
@@ -192,6 +193,7 @@ auto module_app_manager_private_t::do_init() //
                 true);
         }
     }
+#endif // 0
 
     auto hosts_thread = std::thread([] {
         pthread_setname_np(pthread_self(), "flecs-update-hosts");
@@ -204,9 +206,10 @@ auto module_app_manager_private_t::do_init() //
     _mod_jobs = std::dynamic_pointer_cast<module_jobs_t>(api::query_module("jobs"));
 }
 
-auto module_app_manager_private_t::do_load(fs::path base_path) //
+auto module_app_manager_private_t::do_load(fs::path) //
     -> void
 {
+#if 0
     /// @todo remove for 2.0
     // query installed apps and instances from db before deleting it
     auto app_db = app_db_t{};
@@ -256,6 +259,7 @@ auto module_app_manager_private_t::do_load(fs::path base_path) //
             instance.second.app(&it->second);
         }
     }
+#endif // 0
 }
 
 auto module_app_manager_private_t::do_save(fs::path base_path) const //
@@ -282,7 +286,7 @@ auto module_app_manager_private_t::app_versions(std::string_view app_name) const
         _installed_apps.cend(),
         [&](installed_apps_t::const_reference app) {
             if (app.first.name() == app_name) {
-                res.push_back(app.second.version());
+                res.push_back(app.second.key().version().data());
             }
         });
     return res;
@@ -299,9 +303,9 @@ auto module_app_manager_private_t::xcheck_app_instance(
         std::fprintf(
             stderr,
             "Requested instance %s belongs to app %s (%s), which is not installed\n",
-            instance.id().hex().c_str(),
-            app_name.c_str(),
-            version.c_str());
+            instance.id().hex().data(),
+            app_name.data(),
+            version.data());
         return -1;
     }
 
@@ -310,9 +314,9 @@ auto module_app_manager_private_t::xcheck_app_instance(
         std::fprintf(
             stderr,
             "Requested instance %s of app %s belongs to app %s\n",
-            instance.id().hex().c_str(),
-            app_name.c_str(),
-            instance.app_name().c_str());
+            instance.id().hex().data(),
+            app_name.data(),
+            instance.app_name().data());
         return -1;
     }
 
@@ -321,10 +325,10 @@ auto module_app_manager_private_t::xcheck_app_instance(
         std::fprintf(
             stderr,
             "Requested instance %s of app %s (%s) belongs to version %s\n",
-            instance.id().hex().c_str(),
-            instance.app_version().c_str(),
-            version.c_str(),
-            instance.app_version().c_str());
+            instance.id().hex().data(),
+            instance.app_version().data(),
+            version.data(),
+            instance.app_version().data());
         return -1;
     }
 

--- a/daemon/modules/app_manager/src/private/instance_create.cpp
+++ b/daemon/modules/app_manager/src/private/instance_create.cpp
@@ -27,12 +27,13 @@ namespace FLECS {
 namespace Private {
 
 auto module_app_manager_private_t::do_create_instance(
-    const std::string& app_name,
-    const std::string& version,
-    const std::string& instance_name,
-    json_t& response) //
+    const std::string& /*app_name*/,
+    const std::string& /*version*/,
+    const std::string& /*instance_name*/,
+    json_t& /*response*/) //
     -> crow::status
 {
+#if 0
     response["additionalInfo"] = std::string{};
     response["app"] = app_name;
     response["instanceName"] = instance_name;
@@ -70,7 +71,7 @@ auto module_app_manager_private_t::do_create_instance(
         response["additionalInfo"] = "Failed to create instance";
         return crow::status::INTERNAL_SERVER_ERROR;
     }
-
+#endif // 0
     return crow::status::OK;
 }
 

--- a/daemon/modules/app_manager/src/private/instance_delete.cpp
+++ b/daemon/modules/app_manager/src/private/instance_delete.cpp
@@ -22,12 +22,13 @@ namespace FLECS {
 namespace Private {
 
 auto module_app_manager_private_t::do_delete_instance(
-    const instance_id_t& instance_id,
-    const std::string& app_name,
-    const std::string& version,
-    json_t& response) //
+    const instance_id_t& /*instance_id*/,
+    const std::string& /*app_name*/,
+    const std::string& /*version*/,
+    json_t& /*response*/) //
     -> crow::status
 {
+#if 0
     // Provisional response based on request
     response["additionalInfo"] = std::string{};
     response["app"] = app_name;
@@ -94,7 +95,7 @@ auto module_app_manager_private_t::do_delete_instance(
 
     // Final step: Persist removal of instance into db
     persist_apps();
-
+#endif // 0
     return crow::status::OK;
 }
 

--- a/daemon/modules/app_manager/src/private/instance_details.cpp
+++ b/daemon/modules/app_manager/src/private/instance_details.cpp
@@ -22,9 +22,10 @@ namespace FLECS {
 namespace Private {
 
 auto module_app_manager_private_t::do_instance_details(
-    const instance_id_t& instance_id, json_t& response) //
+    const instance_id_t& /*instance_id*/, json_t& /*response*/) //
     -> crow::status
 {
+#if 0
     // Provisional response based on request
     response["additionalInfo"] = std::string{};
     response["instanceId"] = instance_id;
@@ -78,7 +79,7 @@ auto module_app_manager_private_t::do_instance_details(
             response["mounts"].push_back(json_mount);
         }
     }
-
+#endif // 0
     return crow::status::OK;
 }
 

--- a/daemon/modules/app_manager/src/private/instance_export.cpp
+++ b/daemon/modules/app_manager/src/private/instance_export.cpp
@@ -20,11 +20,11 @@
 namespace FLECS {
 namespace Private {
 
-auto module_app_manager_private_t::do_export_instance(const instance_id_t& instance_id) //
+auto module_app_manager_private_t::do_export_instance(const instance_id_t& /*instance_id*/) //
     -> crow::response
 {
     auto response = json_t{};
-
+#if 0
     // Provisional response based on request
     response["additionalInfo"] = std::string{};
     response["app"] = std::string{};
@@ -48,8 +48,8 @@ auto module_app_manager_private_t::do_export_instance(const instance_id_t& insta
     const auto [res, additional_info] =
         _deployment->export_instance(instance, "/var/lib/flecs/export-tmp/instances/");
     response["additionalInfo"] = additional_info;
-
-    return {(res == 0) ? crow::status::OK : crow::status::INTERNAL_SERVER_ERROR, response.dump()};
+#endif // 0
+    return {crow::status::OK, "json", response.dump()};
 }
 
 } // namespace Private

--- a/daemon/modules/app_manager/src/private/instance_update.cpp
+++ b/daemon/modules/app_manager/src/private/instance_update.cpp
@@ -22,13 +22,14 @@ namespace FLECS {
 namespace Private {
 
 auto module_app_manager_private_t::do_update_instance(
-    const instance_id_t& instance_id,
-    const std::string& app_name,
-    const std::string& from,
-    const std::string& to,
-    json_t& response) //
+    const instance_id_t& /*instance_id*/,
+    const std::string& /*app_name*/,
+    const std::string& /*from*/,
+    const std::string& /*to*/,
+    json_t& /*response*/) //
     -> crow::status
 {
+#if 0
     // Provisional response based on request
     response["additionalInfo"] = std::string{};
     response["app"] = app_name;
@@ -151,7 +152,7 @@ auto module_app_manager_private_t::do_update_instance(
             return crow::status::INTERNAL_SERVER_ERROR;
         }
     }
-
+#endif // 0
     return crow::status::OK;
 }
 

--- a/daemon/modules/apps/impl/apps_impl.h
+++ b/daemon/modules/apps/impl/apps_impl.h
@@ -85,7 +85,9 @@ private:
         -> void;
 
     auto do_install_impl(
-        const app_manifest_t& manifest, std::string_view license_key, job_progress_t& progress) //
+        std::shared_ptr<app_manifest_t> manifest,
+        std::string_view license_key,
+        job_progress_t& progress) //
         -> void;
 
     /*! @brief Helper function to determine whether a given app is installed in a given version

--- a/daemon/modules/manifests/CMakeLists.txt
+++ b/daemon/modules/manifests/CMakeLists.txt
@@ -19,7 +19,7 @@ flecs_add_module(
     ADDITIONAL_HEADERS
     impl/manifests_impl.h
     LIBS_PRIVATE
-    FLECS.external.cpr FLECS.daemon.common.app FLECS.daemon.common.app.manifest
+    FLECS.external.cpr daemon.common.app FLECS.daemon.common.app.manifest
 )
 
 add_subdirectory(test)


### PR DESCRIPTION
With the new manifests module, apps and manifests are more loosely coupled, which should be reflected in the class hierarchy. An App no now longer inherits from manifest, but weakly references its according manifest in the manifests module itself