### PR TITLE
daemon: migrate app_manager code to instances

### DIFF
--- a/daemon/CMakeLists.txt
+++ b/daemon/CMakeLists.txt
@@ -51,6 +51,7 @@ target_link_libraries(FLECS.daemon PRIVATE
     FLECS.daemon.modules.data_layer
     FLECS.daemon.modules.factory
     FLECS.daemon.modules.help
+    FLECS.daemon.modules.instances
     FLECS.daemon.modules.jobs
     FLECS.daemon.modules.manifests
     FLECS.daemon.modules.marketplace

--- a/daemon/modules/instances/impl/instances_impl.h
+++ b/daemon/modules/instances/impl/instances_impl.h
@@ -15,34 +15,88 @@
 #pragma once
 
 #include <memory>
+#include <mutex>
 
-#include "module_base/module.h"
+#include "instances.h"
 
 namespace FLECS {
 
+class deployment_t;
 class job_progress_t;
-class module_instances_t;
+class module_apps_t;
 class module_jobs_t;
 
 namespace impl {
 
-class module_instances_impl_t
+class module_instances_t
 {
     friend class FLECS::module_instances_t;
 
 public:
-    ~module_instances_impl_t();
+    ~module_instances_t();
 
 private:
-    explicit module_instances_impl_t(module_instances_t* parent);
+    explicit module_instances_t(FLECS::module_instances_t* parent);
 
     auto do_init() //
         -> void;
 
-    module_instances_t* _parent;
+    auto do_list(const app_key_t& app_key) const //
+        -> crow::response;
 
-    std::mutex _installed_apps_mutex;
+    auto queue_create(app_key_t app_key, std::string instance_name) //
+        -> crow::response;
 
+    auto do_create(app_key_t app_key, std::string instance_name, job_progress_t& progress) //
+        -> void;
+
+    auto queue_start(instance_id_t instance_id) //
+        -> crow::response;
+
+    auto do_start(instance_id_t instance_id, job_progress_t& progress) //
+        -> void;
+
+    auto queue_stop(instance_id_t instance_id) //
+        -> crow::response;
+
+    auto do_stop(instance_id_t instance_id, job_progress_t& progress) //
+        -> void;
+
+    auto queue_remove(instance_id_t instance_id) //
+        -> crow::response;
+
+    auto do_remove(instance_id_t instance_id, job_progress_t& progress) //
+        -> void;
+
+    auto do_get_config(instance_id_t instance_id) const //
+        -> crow::response;
+
+    auto do_post_config(instance_id_t instance_id, const instance_config_t& config) //
+        -> crow::response;
+
+    auto do_details(instance_id_t instance_id) const //
+        -> crow::response;
+
+    auto do_logs(instance_id_t instance_id) const //
+        -> crow::response;
+
+    auto queue_update(instance_id_t instance_id, std::string from, std::string to) //
+        -> crow::response;
+
+    auto do_update(
+        instance_id_t instance_id, std::string from, std::string to, job_progress_t& progress) //
+        -> void;
+
+    auto queue_export(instance_id_t instance_id) //
+        -> crow::response;
+
+    auto do_export(instance_id_t instance_id, job_progress_t& progress) //
+        -> void;
+
+    FLECS::module_instances_t* _parent;
+
+    std::unique_ptr<deployment_t> _deployment;
+    std::shared_ptr<FLECS::module_apps_t> _apps_api;
     std::shared_ptr<FLECS::module_jobs_t> _jobs_api;
 };
 

--- a/daemon/modules/instances/instances.h
+++ b/daemon/modules/instances/instances.h
@@ -14,20 +14,73 @@
 
 #pragma once
 
-#include <memory>
-
+#include "common/instance/instance_id.h"
 #include "module_base/module.h"
 
 namespace FLECS {
 
+class app_key_t;
+class instance_config_t;
+
 namespace impl {
-class module_instances_impl_t;
+class module_instances_t;
 } // namespace impl
 
 class module_instances_t FLECS_FINAL_UNLESS_TESTED : public module_t
 {
 public:
     ~module_instances_t() override;
+
+    /*! @brief Lists all available instances
+     *
+     * @param app_key (optional) limit list to all or specific version of specific App
+     *
+     * @return HTTP response
+     */
+    auto list(const app_key_t& app_key) const //
+        -> crow::response;
+    auto list(std::string app_name, std::string version) const //
+        -> crow::response;
+    auto list(std::string app_name) const //
+        -> crow::response;
+    auto list() const //
+        -> crow::response;
+
+    auto create(app_key_t app_key, std::string instance_name) //
+        -> crow::response;
+    auto create(app_key_t app_key) //
+        -> crow::response;
+    auto create(std::string app_name, std::string version, std::string instance_name) //
+        -> crow::response;
+    auto create(std::string app_name, std::string version) //
+        -> crow::response;
+
+    auto start(instance_id_t instance_id) //
+        -> crow::response;
+
+    auto stop(instance_id_t instance_id) //
+        -> crow::response;
+
+    auto remove(instance_id_t instance_id) //
+        -> crow::response;
+
+    auto get_config(instance_id_t instance_id) const //
+        -> crow::response;
+
+    auto post_config(instance_id_t instance_id, const instance_config_t& config) //
+        -> crow::response;
+
+    auto details(instance_id_t instance_id) const //
+        -> crow::response;
+
+    auto logs(instance_id_t instance_id) const //
+        -> crow::response;
+
+    auto update(instance_id_t instance_id, std::string from, std::string to) //
+        -> crow::response;
+
+    auto archive(instance_id_t instance_id) const //
+        -> crow::response;
 
 protected:
     friend class module_factory_t;
@@ -37,7 +90,7 @@ protected:
     void do_init() override;
     void do_deinit() override {}
 
-    std::unique_ptr<impl::module_instances_impl_t> _impl;
+    std::unique_ptr<impl::module_instances_t> _impl;
 };
 
 } // namespace FLECS

--- a/daemon/modules/instances/src/impl/instances_impl.cpp
+++ b/daemon/modules/instances/src/impl/instances_impl.cpp
@@ -15,25 +15,615 @@
 #include "impl/instances_impl.h"
 
 #include "api/api.h"
+#include "common/app/app.h"
+#include "common/app/manifest/manifest.h"
+#include "common/deployment/deployment_docker.h"
+#include "modules/apps/apps.h"
 #include "modules/factory/factory.h"
 #include "modules/jobs/jobs.h"
+#include "modules/system/system.h"
+#include "util/cxx20/string.h"
+#include "util/network/network.h"
+#include "util/process/process.h"
 
 namespace FLECS {
 namespace impl {
 
-module_instances_impl_t::module_instances_impl_t(module_instances_t* parent)
+namespace {
+auto build_network_adapters_json(std::shared_ptr<instance_t> instance)
+{
+    const auto system_api = dynamic_cast<const module_system_t*>(api::query_module("system").get());
+    const auto adapters = system_api->get_network_adapters();
+    auto adapters_json = json_t::array();
+    for (decltype(auto) adapter : adapters) {
+        if ((adapter.second.type == netif_type_t::WIRED) ||
+            (adapter.second.type == netif_type_t::WIRELESS)) {
+            auto adapter_json = json_t{};
+            adapter_json["name"] = adapter.first;
+            adapter_json["active"] = false;
+            adapter_json["connected"] = !adapter.second.ipv4_addr.empty();
+            auto network = std::string{"flecs-macvlan-"} + adapter.first;
+            auto it = std::find_if(
+                instance->networks().cbegin(),
+                instance->networks().cend(),
+                [&](const instance_t::network_t& n) { return n.network_name == network; });
+            if (it != instance->networks().cend()) {
+                adapter_json["active"] = true;
+                adapter_json["ipAddress"] = it->ip_address;
+                if (adapter.second.ipv4_addr.empty()) {
+                    adapter_json["subnetMask"] = "0.0.0.0";
+                    adapter_json["gateway"] = "0.0.0.0";
+                } else {
+                    adapter_json["subnetMask"] = adapter.second.ipv4_addr.begin()->subnet_mask;
+                    adapter_json["gateway"] = adapter.second.gateway;
+                }
+            }
+            adapters_json.push_back(adapter_json);
+        }
+    }
+    for (decltype(auto) network : instance->networks()) {
+        if (cxx20::starts_with(network.network_name, "flecs-macvlan-")) {
+            const auto adapter = network.network_name.substr(14);
+            if (!adapters.count(adapter)) {
+                auto adapter_json = json_t{};
+                adapter_json["name"] = adapter;
+                adapter_json["active"] = true;
+                adapter_json["connected"] = false;
+                adapter_json["ipAddress"] = network.ip_address;
+                adapter_json["subnetMask"] = "0.0.0.0";
+                adapter_json["gateway"] = "0.0.0.0";
+
+                adapters_json.push_back(std::move(adapter_json));
+            }
+        }
+    }
+    return adapters_json;
+}
+
+auto build_usb_devices_json(std::shared_ptr<instance_t> instance)
+{
+    auto ret = json_t::array();
+    const auto usb_devices = usb::get_devices();
+
+    // insert connected usb device
+    for (decltype(auto) usb_device : usb_devices) {
+        auto device_json = json_t(usb_device);
+        device_json["active"] = static_cast<bool>(instance->usb_devices().count(usb_device));
+        device_json["connected"] = true;
+        ret.push_back(std::move(device_json));
+    }
+
+    // insert configured, but disconnected usb devices
+    for (decltype(auto) usb_device : instance->usb_devices()) {
+        if (!usb_devices.count(usb_device)) {
+            auto device_json = json_t(usb_device);
+            device_json["active"] = true;
+            device_json["connected"] = false;
+            ret.push_back(std::move(device_json));
+        }
+    }
+
+    return ret;
+}
+} // namespace
+
+module_instances_t::module_instances_t(FLECS::module_instances_t* parent)
     : _parent{parent}
+    , _deployment{new deployment_docker_t{}}
+    , _apps_api{}
     , _jobs_api{}
 {}
 
-module_instances_impl_t::~module_instances_impl_t()
+module_instances_t::~module_instances_t()
 {}
 
-auto module_instances_impl_t::do_init() //
+auto module_instances_t::do_init() //
     -> void
 {
+    _apps_api = std::dynamic_pointer_cast<FLECS::module_apps_t>(api::query_module("apps"));
     _jobs_api = std::dynamic_pointer_cast<FLECS::module_jobs_t>(api::query_module("jobs"));
 }
+
+auto module_instances_t::do_list(const app_key_t& /*app_key*/) const //
+    -> crow::response
+{
+    auto response = json_t::array();
+
+    for (const auto& instance_id : _deployment->instance_ids()) {
+        auto json = json_t::object();
+
+        auto instance = _deployment->query_instance(instance_id);
+
+        json["instanceId"] = instance->id().hex();
+        if (auto app = instance->app()) {
+            json["appKey"] = app->key();
+            if (instance->status() == instance_status_e::Created) {
+                json["status"] = to_string(
+                    _deployment->is_instance_running(instance) ? instance_status_e::Running
+                                                               : instance_status_e::Stopped);
+            } else {
+                json["status"] = to_string(instance->status());
+            }
+        } else {
+            json["appKey"] = app_key_t{};
+            json["status"] = instance_status_e::Orphaned;
+        }
+        json["desired"] = to_string(instance->desired());
+        response.push_back(std::move(json));
+    }
+
+    return {crow::status::OK, "json", response.dump()};
+}
+
+auto module_instances_t::queue_create(app_key_t app_key, std::string instance_name) //
+    -> crow::response
+{
+    auto job = job_t{};
+    job.callable = std::bind(
+        &module_instances_t::do_create,
+        this,
+        std::move(app_key),
+        std::move(instance_name),
+        std::placeholders::_1);
+
+    auto job_id = _jobs_api->append(std::move(job));
+
+    auto response = json_t::object();
+    response["jobId"] = std::to_string(job_id);
+    return {crow::status::ACCEPTED, "json", response.dump()};
+}
+
+auto module_instances_t::do_create(
+    app_key_t app_key, std::string instance_name, job_progress_t& progress) //
+    -> void
+{
+    // Step 1: Ensure app is actually installed
+    auto app = _apps_api->query(app_key);
+    if (!app || (app->status() != app_status_e::Installed)) {
+        auto lock = progress.lock();
+        progress.result().code = -1;
+        progress.result().message =
+            "Could not create instance of " + to_string(app_key) + ": not installed";
+        return;
+    }
+
+    // Step 2: Load app manifest
+    const auto manifest = app->manifest();
+    if (!manifest || !manifest->is_valid()) {
+        auto lock = progress.lock();
+        progress.result().code = -1;
+        progress.result().message =
+            "Could not create instance of " + to_string(app_key) + ": manifest error";
+        return;
+    }
+
+    // Step 3: Ensure there is only one instance of single-instance apps
+    if (!manifest->multi_instance()) {
+        const auto instance_ids = _deployment->instance_ids(app->key(), deployment_t::MatchVersion);
+        if (!instance_ids.empty()) {
+            auto instance = _deployment->query_instance(instance_ids.front());
+            instance->app(std::move(app));
+
+            auto lock = progress.lock();
+            progress.result().code = 0;
+            progress.result().message = instance->id().hex();
+            return;
+        }
+    }
+
+    // Step 4: Forward to deployment
+    const auto [res, instance_id] = _deployment->create_instance(std::move(app), instance_name);
+
+    // Final step: Persist creation into db
+    _deployment->save();
+
+    if (res != 0) {
+        auto lock = progress.lock();
+        progress.result().code = -1;
+        progress.result().message = "Could not create instance of " + to_string(app_key);
+        return;
+    }
+
+    auto lock = progress.lock();
+    progress.result().code = 0;
+    progress.result().message = instance_id;
+}
+
+auto module_instances_t::queue_start(instance_id_t instance_id) //
+    -> crow::response
+{
+    auto job = job_t{};
+    job.callable = std::bind(
+        &module_instances_t::do_start,
+        this,
+        std::move(instance_id),
+        std::placeholders::_1);
+
+    auto job_id = _jobs_api->append(std::move(job));
+
+    auto response = json_t::object();
+    response["jobId"] = std::to_string(job_id);
+    return {crow::status::ACCEPTED, "json", response.dump()};
+}
+
+auto module_instances_t::do_start(instance_id_t instance_id, job_progress_t& progress) //
+    -> void
+{
+    auto instance = _deployment->query_instance(instance_id);
+    // Step 1: Verify instance does actually exist and is fully created
+    if (!_deployment->is_instance_runnable(instance)) {
+        auto lock = progress.lock();
+        progress.result().code = -1;
+        progress.result().message =
+            instance ? "Instance not fully created" : "Instance does not exist";
+    }
+
+    // Step 3: Return if instance is already running
+    if (_deployment->is_instance_running(instance)) {
+        auto lock = progress.lock();
+        progress.result().message = "Instance already running";
+    }
+
+    // Step 3: Persist desired status into deployment
+    /** @todo implement start_once without persistence */
+    instance->desired(instance_status_e::Running);
+
+    // Step 4: Forward to deployment
+    const auto [res, additional_info] = _deployment->start_instance(instance);
+
+    // Final step: Persist instance status into deployment
+    _deployment->save();
+
+    auto lock = progress.lock();
+    progress.result().code = std::move(res);
+    progress.result().message = std::move(additional_info);
+}
+
+auto module_instances_t::queue_stop(instance_id_t instance_id) //
+    -> crow::response
+{
+    auto job = job_t{};
+    job.callable = std::bind(
+        &module_instances_t::do_stop,
+        this,
+        std::move(instance_id),
+        std::placeholders::_1);
+
+    auto job_id = _jobs_api->append(std::move(job));
+
+    auto response = json_t::object();
+    response["jobId"] = std::to_string(job_id);
+    return {crow::status::ACCEPTED, "json", response.dump()};
+}
+
+auto module_instances_t::do_stop(instance_id_t instance_id, job_progress_t& progress) //
+    -> void
+{
+    // get instance details from database
+    auto instance = _deployment->query_instance(instance_id);
+
+    if (!instance) {
+        auto lock = progress.lock();
+        progress.result().code = -1;
+        progress.result().message = "Instance does not exist";
+    }
+
+    // Step 3: Return if instance is not running
+    if (!_deployment->is_instance_running(instance)) {
+        auto lock = progress.lock();
+        progress.result().message = "Instance not running";
+    }
+
+    // Step 4: Persist desired status into db
+    instance->desired(instance_status_e::Stopped);
+
+    // Step 5: Forward to deployment
+    const auto [res, additional_info] = _deployment->stop_instance(instance);
+
+    // Final step: Persist instance status into deployment
+    _deployment->save();
+
+    auto lock = progress.lock();
+    progress.result().code = std::move(res);
+    progress.result().message = std::move(additional_info);
+}
+
+auto module_instances_t::queue_remove(instance_id_t instance_id) //
+    -> crow::response
+{
+    auto job = job_t{};
+    job.callable = std::bind(
+        &module_instances_t::do_remove,
+        this,
+        std::move(instance_id),
+        std::placeholders::_1);
+
+    auto job_id = _jobs_api->append(std::move(job));
+
+    auto response = json_t::object();
+    response["jobId"] = std::to_string(job_id);
+    return {crow::status::ACCEPTED, "json", response.dump()};
+}
+
+auto module_instances_t::do_remove(
+    instance_id_t instance_id,
+    job_progress_t& progress) //
+    -> void
+{
+    // Step 1: Verify instance does actually exist
+    auto instance = _deployment->query_instance(instance_id);
+    if (!instance) {
+        auto lock = progress.lock();
+        progress.result().code = -1;
+        progress.result().message = "Instance does not exist";
+    }
+
+    // Step 2: Attempt to stop instance
+    _deployment->stop_instance(instance);
+
+    // Step 3: Remove volumes of instance
+    _deployment->delete_volumes(instance);
+
+    /// @todo: move functionality to deployment
+    _deployment->delete_instance(instance);
+    _deployment->save();
+}
+
+auto module_instances_t::do_get_config(instance_id_t instance_id) const //
+    -> crow::response
+{
+    auto response = json_t();
+
+    // Step 1: Verify instance does actually exist
+    auto instance = _deployment->query_instance(instance_id);
+    if (!instance) {
+        return {crow::status::NOT_FOUND, {}};
+    }
+
+    response["networkAdapters"] = build_network_adapters_json(instance);
+    response["devices"]["usb"] = build_usb_devices_json(instance);
+
+    return {crow::status::OK, "json", {}};
+}
+
+auto module_instances_t::do_post_config(
+    instance_id_t instance_id, const instance_config_t& config) //
+    -> crow::response
+{
+    // Step 1: Verify instance does actually exist
+    auto instance = _deployment->query_instance(instance_id);
+    if (!instance) {
+        return {crow::status::NOT_FOUND, {}};
+    }
+
+    auto response = json_t();
+    response["networkAdapters"] = build_network_adapters_json(instance);
+
+    const auto system_api = dynamic_cast<const module_system_t*>(api::query_module("system").get());
+    const auto adapters = system_api->get_network_adapters();
+
+    for (const auto& network : config.networkAdapters) {
+        const auto docker_network = std::string{"flecs-macvlan-"} + network.name;
+        if (network.active) {
+            // ensure network adapter exists
+            const auto netif = adapters.find(network.name);
+            if (netif == adapters.cend()) {
+                continue;
+            }
+            if (netif->second.ipv4_addr.empty()) {
+                response["additionalInfo"] = "Network adapter " + netif->first + " not ready";
+                continue;
+            }
+
+            // create macvlan network, if not exists
+            const auto cidr_subnet = ipv4_to_network(
+                netif->second.ipv4_addr[0].addr,
+                netif->second.ipv4_addr[0].subnet_mask);
+
+            // process instance configuration
+            if (network.ipAddress.empty()) {
+                // suggest suitable IP address
+                for (auto& adapter_json : response["networkAdapters"]) {
+                    if (adapter_json["name"] == netif->first) {
+                        adapter_json["active"] = true;
+                        adapter_json["ipAddress"] =
+                            _deployment->generate_instance_ip(cidr_subnet, netif->second.gateway);
+                        adapter_json["subnetMask"] = netif->second.ipv4_addr[0].subnet_mask;
+                        adapter_json["gateway"] = netif->second.gateway;
+                        break;
+                    }
+                }
+            } else {
+                // apply settings
+                // @todo verify validity of IP address
+                _deployment->create_network(
+                    network_type_e::MACVLAN,
+                    docker_network,
+                    cidr_subnet,
+                    netif->second.gateway,
+                    netif->first);
+
+                _deployment->disconnect_network(instance, docker_network);
+
+                const auto [res, additional_info] =
+                    _deployment->connect_network(instance, docker_network, network.ipAddress);
+
+                if (res == 0) {
+                    auto it = std::find_if(
+                        instance->networks().begin(),
+                        instance->networks().end(),
+                        [&](const instance_t::network_t& n) {
+                            return n.network_name == docker_network;
+                        });
+                    if (it != instance->networks().end()) {
+                        it->ip_address = network.ipAddress;
+                    } else {
+                        instance->networks().emplace_back(instance_t::network_t{
+                            .network_name = docker_network,
+                            .mac_address = {},
+                            .ip_address = network.ipAddress});
+                    }
+                    _deployment->save();
+                    for (auto& adapter_json : response["networkAdapters"]) {
+                        if (adapter_json.contains("name") &&
+                            (adapter_json["name"] == netif->first)) {
+                            adapter_json["active"] = true;
+                            adapter_json["ipAddress"] = network.ipAddress;
+                        }
+                    }
+                } else {
+                    response["additionalInfo"] = additional_info;
+                    for (auto& adapter_json : response["networkAdapters"]) {
+                        if (adapter_json["name"] == netif->first) {
+                            adapter_json["active"] = false;
+                        }
+                    }
+                }
+            }
+        } else {
+            _deployment->disconnect_network(instance, docker_network);
+            _deployment->delete_network(docker_network);
+
+            instance->networks().erase(
+                std::remove_if(
+                    instance->networks().begin(),
+                    instance->networks().end(),
+                    [&](const instance_t::network_t& net) {
+                        return net.network_name == docker_network;
+                    }),
+                instance->networks().end());
+
+            for (auto& adapter_json : response["networkAdapters"]) {
+                if (adapter_json.contains("name") && (adapter_json["name"] == network.name)) {
+                    adapter_json["active"] = false;
+                }
+            }
+        }
+    }
+
+    for (const auto& usb_device : config.usb_devices) {
+        if (usb_device.active) {
+            instance->usb_devices().emplace(usb_device);
+        } else {
+            instance->usb_devices().erase(usb_device);
+        }
+    }
+    response["devices"]["usb"] = build_usb_devices_json(instance);
+
+    return {crow::status::OK, "json", {}};
+}
+
+auto module_instances_t::do_details(instance_id_t instance_id) const //
+    -> crow::response
+{
+    // Step 1: Verify instance does actually exist
+    auto instance = _deployment->query_instance(instance_id);
+    if (!instance) {
+        return {crow::status::NOT_FOUND, {}};
+    }
+
+    auto response = json_t();
+    // Step 2: Obtain corresponding app and manifest
+    auto app = instance->app();
+    if (!app) {
+        response["additionalInfo"] = "Instance not connected to an App";
+        return {crow::status::INTERNAL_SERVER_ERROR, "json", response.dump()};
+    }
+
+    auto manifest = app->manifest();
+    if (!manifest) {
+        response["additionalInfo"] = "App not connected to a Manifest";
+        return {crow::status::INTERNAL_SERVER_ERROR, "json", response.dump()};
+    }
+
+    // Build response
+    response["instanceId"] = instance->id().hex();
+    response["appKey"] = app->key();
+    response["status"] = to_string(instance->status());
+    response["desired"] = to_string(instance->desired());
+    response["ipAddress"] = instance->networks().empty() ? "" : instance->networks()[0].ip_address;
+    response["configFiles"] = json_t::array();
+    for (const auto& config_file : manifest->conffiles()) {
+        auto json = json_t{};
+        json["host"] =
+            "/var/lib/flecs/instances/" + instance->id().hex() + "/conf/" + config_file.local();
+        json["container"] = config_file.container();
+        response["configFiles"].push_back(json);
+    }
+    response["hostname"] =
+        manifest->hostname().empty() ? ("flecs-" + instance->id().hex()) : manifest->hostname();
+    response["ports"] = json_t::array();
+    for (const auto& port : manifest->ports()) {
+        auto json_port = json_t{};
+        json_port["host"] = to_string(port.host_port_range());
+        json_port["container"] = to_string(port.container_port_range());
+        response["ports"].push_back(json_port);
+    }
+    response["volumes"] = json_t::array();
+    for (const auto& volume : manifest->volumes()) {
+        if (volume.type() == volume_t::VOLUME) {
+            auto json_volume = json_t{};
+            json_volume["name"] = volume.host();
+            json_volume["path"] = volume.container();
+            response["volumes"].push_back(json_volume);
+        }
+    }
+
+    return {crow::status::OK, "json", response.dump()};
+}
+
+auto module_instances_t::do_logs(instance_id_t instance_id) const //
+    -> crow::response
+{
+    // Step 1: Verify instance does actually exist
+    auto instance = _deployment->query_instance(instance_id);
+    if (!instance) {
+        return {crow::status::NOT_FOUND, {}};
+    }
+
+    auto response = json_t{};
+
+    // Step 2: Obtain log from Docker
+    auto docker_process = process_t{};
+    docker_process.spawnp("docker", "logs", "flecs-" + instance->id().hex());
+    docker_process.wait(false, false);
+
+    // Step 3: Build response
+    if (docker_process.exit_code() != 0) {
+        response["additionalInfo"] = "Could not get logs for instance " + instance->id().hex();
+        return {crow::status::INTERNAL_SERVER_ERROR, "json", response.dump()};
+    }
+
+    response["stdout"] = docker_process.stdout();
+    response["stderr"] = docker_process.stderr();
+
+    return {crow::status::OK, "json", response.dump()};
+}
+
+auto module_instances_t::queue_update(
+    instance_id_t /*instance_id*/, std::string /*from*/, std::string /*to*/) //
+    -> crow::response
+{
+    return {crow::status::ACCEPTED, "json", {}};
+}
+
+auto module_instances_t::do_update(
+    instance_id_t /*instance_id*/,
+    std::string /*from*/,
+    std::string /*to*/,
+    job_progress_t& /*progress*/) //
+    -> void
+{}
+
+auto module_instances_t::queue_export(instance_id_t /*instance_id*/) //
+    -> crow::response
+{
+    return {crow::status::ACCEPTED, "json", {}};
+}
+
+auto module_instances_t::do_export(instance_id_t /*instance_id*/, job_progress_t& /*progress*/) //
+    -> void
+{}
 
 } // namespace impl
 } // namespace FLECS

--- a/daemon/modules/instances/src/instances.cpp
+++ b/daemon/modules/instances/src/instances.cpp
@@ -14,17 +14,19 @@
 
 #include "instances.h"
 
+#include "common/app/app_key.h"
+#include "common/instance/instance_config.h"
 #include "factory/factory.h"
 #include "impl/instances_impl.h"
 
 namespace FLECS {
 
 namespace {
-register_module_t<module_instances_t> _reg("apps");
+register_module_t<module_instances_t> _reg("instances");
 }
 
 module_instances_t::module_instances_t()
-    : _impl{new impl::module_instances_impl_t{this}}
+    : _impl{new impl::module_instances_t{this}}
 {}
 
 module_instances_t::~module_instances_t()
@@ -33,7 +35,167 @@ module_instances_t::~module_instances_t()
 auto module_instances_t::do_init() //
     -> void
 {
+    FLECS_V2_ROUTE("/instances").methods("GET"_method)([this](const crow::request& req) {
+        auto app = req.url_params.get("app");
+        auto version = req.url_params.get("version");
+        return list(app ? app : "", version ? version : "");
+    });
+
+    FLECS_V2_ROUTE("/instances/<string>")
+        .methods("GET"_method)(
+            [this](const std::string& instance_id) { return details(instance_id_t{instance_id}); });
+
+    FLECS_V2_ROUTE("/instances/create").methods("POST"_method)([this](const crow::request& req) {
+        auto response = json_t{};
+        const auto args = parse_json(req.body);
+        REQUIRED_TYPED_JSON_VALUE(args, appKey, app_key_t);
+        OPTIONAL_JSON_VALUE(args, instanceName);
+        return create(std::move(appKey), std::move(instanceName));
+    });
+
+    FLECS_V2_ROUTE("/instances/<string>")
+        .methods("DELETE"_method)(
+            [this](const std::string& instance_id) { return remove(instance_id_t{instance_id}); });
+
+    FLECS_V2_ROUTE("/instances/<string>/start")
+        .methods("POST"_method)(
+            [this](const std::string& instance_id) { return start(instance_id_t{instance_id}); });
+
+    FLECS_V2_ROUTE("/instances/<string>/stop")
+        .methods("POST"_method)(
+            [this](const std::string& instance_id) { return stop(instance_id_t{instance_id}); });
+
+    FLECS_V2_ROUTE("/instances/<string>/config")
+        .methods("GET"_method)([this](const std::string& instance_id) {
+            return get_config(instance_id_t{instance_id});
+        });
+
+    FLECS_V2_ROUTE("/instances/<string>/config")
+        .methods("POST"_method)([this](const crow::request& req, const std::string& instance_id) {
+            auto response = json_t{};
+            const auto args = parse_json(req.body);
+            auto config = instance_config_t{};
+            if (args.contains("networkAdapters")) {
+                args["networkAdapters"].get_to(config.networkAdapters);
+            }
+            if (args.contains("devices") && args["devices"].contains("usb")) {
+                args["devices"]["usb"].get_to(config.usb_devices);
+            }
+
+            return post_config(instance_id_t{instance_id}, config);
+        });
+
+    FLECS_V2_ROUTE("/instances/<string>/logs")
+        .methods("GET"_method)(
+            [this](const std::string& instance_id) { return logs(instance_id_t{instance_id}); });
+
     return _impl->do_init();
+}
+
+auto module_instances_t::list(const app_key_t& app_key) const //
+    -> crow::response
+{
+    return _impl->do_list(app_key);
+}
+auto module_instances_t::list(std::string app_name, std::string version) const //
+    -> crow::response
+{
+    return list(app_key_t{std::move(app_name), std::move(version)});
+}
+auto module_instances_t::list(std::string app_name) const //
+    -> crow::response
+{
+    return list(std::move(app_name), {});
+}
+auto module_instances_t::list() const //
+    -> crow::response
+{
+    return list({}, {});
+}
+
+auto module_instances_t::create(
+    app_key_t app_key,
+    std::string instance_name) //
+    -> crow::response
+{
+    return _impl->queue_create(std::move(app_key), std::move(instance_name));
+}
+
+auto module_instances_t::create(app_key_t app_key) //
+    -> crow::response
+{
+    return create(std::move(app_key), {});
+}
+
+auto module_instances_t::create(
+    std::string app_name,
+    std::string version,
+    std::string instance_name) //
+    -> crow::response
+{
+    return create(app_key_t{std::move(app_name), std::move(version)}, std::move(instance_name));
+}
+
+auto module_instances_t::create(
+    std::string app_name,
+    std::string version) //
+    -> crow::response
+{
+    return create(std::move(app_name), std::move(version), {});
+}
+
+auto module_instances_t::start(instance_id_t instance_id) //
+    -> crow::response
+{
+    return _impl->queue_start(std::move(instance_id));
+}
+
+auto module_instances_t::stop(instance_id_t instance_id) //
+    -> crow::response
+{
+    return _impl->queue_stop(std::move(instance_id));
+}
+
+auto module_instances_t::remove(instance_id_t instance_id) //
+    -> crow::response
+{
+    return _impl->queue_remove(std::move(instance_id));
+}
+
+auto module_instances_t::get_config(instance_id_t instance_id) const //
+    -> crow::response
+{
+    return _impl->do_get_config(std::move(instance_id));
+}
+
+auto module_instances_t::post_config(instance_id_t instance_id, const instance_config_t& config) //
+    -> crow::response
+{
+    return _impl->do_post_config(std::move(instance_id), config);
+}
+
+auto module_instances_t::details(instance_id_t instance_id) const //
+    -> crow::response
+{
+    return _impl->do_details(std::move(instance_id));
+}
+
+auto module_instances_t::logs(instance_id_t instance_id) const //
+    -> crow::response
+{
+    return _impl->do_logs(std::move(instance_id));
+}
+
+auto module_instances_t::update(instance_id_t instance_id, std::string from, std::string to) //
+    -> crow::response
+{
+    return _impl->queue_update(std::move(instance_id), std::move(from), std::move(to));
+}
+
+auto module_instances_t::archive(instance_id_t instance_id) const //
+    -> crow::response
+{
+    return _impl->queue_export(std::move(instance_id));
 }
 
 } // namespace FLECS


### PR DESCRIPTION
After splitting up app_manager into a manifests, an apps and an instances module, working old code has to be moved to each new module. This commit migrates app_manager code related to instance management to the new instances module.