### PR TITLE
daemon: fix potential crash if instance cleanup is unsucessful

### DIFF
--- a/daemon/common/deployment/src/deployment.cpp
+++ b/daemon/common/deployment/src/deployment.cpp
@@ -68,16 +68,10 @@ auto deployment_t::instance_ids(const app_key_t& app_key, version_filter_e versi
 {
     auto ids = std::vector<instance_id_t>{};
     for (const auto& instance : _instances) {
-        const auto app = instance->app();
-        if (!app && app_key.name().empty()) {
-            ids.emplace_back(instance->id());
-            continue;
-        }
-
-        const auto apps_match = app_key.name().empty() || (app_key.name() == app->key().name());
+        const auto apps_match = app_key.name().empty() || (app_key.name() == instance->app_name());
         const auto versions_match = app_key.name().empty() || app_key.version().empty() ||
                                     version_filter == AllVersions ||
-                                    (app_key.version() == app->key().version());
+                                    (app_key.version() == instance->app_version());
         if (apps_match && versions_match) {
             ids.emplace_back(instance->id());
         }


### PR DESCRIPTION
In case an instance remains throughout uninstallation of an App (e.g. as instance deletion is unsuccessful or not performed due to shutdown ...), creating a new instance after reinstallation of this App should pick up the leftover instance and reactivate it. However, this currently leads to a crash as pointers are not checked in the according code path.

Instead of direct pointer access, use the safe interface provided by the instance, which returns a valid result even if the instance is currently orphaned.