### PR TITLE
instances: split interface into http and synchronous

### DIFF
--- a/daemon/modules/instances/impl/instances_impl.h
+++ b/daemon/modules/instances/impl/instances_impl.h
@@ -16,6 +16,7 @@
 
 #include <memory>
 #include <mutex>
+#include <vector>
 
 #include "instances.h"
 
@@ -41,30 +42,43 @@ private:
     auto do_init() //
         -> void;
 
+    auto do_instance_ids(const app_key_t& app_key) const //
+        -> std::vector<instance_id_t>;
+
+    auto do_query(instance_id_t instance_id) const //
+        -> std::shared_ptr<instance_t>;
+
+    auto do_is_running(std::shared_ptr<instance_t> instance) const //
+        -> bool;
+
     auto do_list(const app_key_t& app_key) const //
-        -> crow::response;
+        -> std::vector<instance_id_t>;
 
     auto queue_create(app_key_t app_key, std::string instance_name) //
-        -> crow::response;
-
+        -> job_id_t;
+    auto do_create_sync(app_key_t app_key, std::string instance_name) //
+        -> result_t;
     auto do_create(app_key_t app_key, std::string instance_name, job_progress_t& progress) //
         -> result_t;
 
     auto queue_start(instance_id_t instance_id) //
-        -> crow::response;
-
+        -> job_id_t;
+    auto do_start_sync(instance_id_t instance_id) //
+        -> result_t;
     auto do_start(instance_id_t instance_id, job_progress_t& progress) //
         -> result_t;
 
     auto queue_stop(instance_id_t instance_id) //
-        -> crow::response;
-
+        -> job_id_t;
+    auto do_stop_sync(instance_id_t instance_id) //
+        -> result_t;
     auto do_stop(instance_id_t instance_id, job_progress_t& progress) //
         -> result_t;
 
     auto queue_remove(instance_id_t instance_id) //
-        -> crow::response;
-
+        -> job_id_t;
+    auto do_remove_sync(instance_id_t instance_id) //
+        -> result_t;
     auto do_remove(instance_id_t instance_id, job_progress_t& progress) //
         -> result_t;
 
@@ -80,15 +94,15 @@ private:
     auto do_logs(instance_id_t instance_id) const //
         -> crow::response;
 
-    auto queue_update(instance_id_t instance_id, std::string from, std::string to) //
-        -> crow::response;
-
-    auto do_update(
-        instance_id_t instance_id, std::string from, std::string to, job_progress_t& progress) //
+    auto queue_update(instance_id_t instance_id, std::string to) //
+        -> job_id_t;
+    auto do_update_sync(instance_id_t instance_id, std::string to) //
+        -> result_t;
+    auto do_update(instance_id_t instance_id, std::string to, job_progress_t& progress) //
         -> result_t;
 
     auto queue_export_to(instance_id_t instance_id, fs::path dest_dir) //
-        -> crow::response;
+        -> job_id_t;
 
     auto do_export_to(instance_id_t instance_id, fs::path dest_dir, job_progress_t& progress) //
         -> result_t;

--- a/daemon/modules/instances/instances.h
+++ b/daemon/modules/instances/instances.h
@@ -14,14 +14,19 @@
 
 #pragma once
 
+#include <memory>
+#include <vector>
+
 #include "common/instance/instance_id.h"
 #include "module_base/module.h"
+#include "modules/jobs/job_id.h"
 #include "util/fs/fs.h"
 
 namespace FLECS {
 
 class app_key_t;
 class instance_config_t;
+class instance_t;
 
 namespace impl {
 class module_instances_t;
@@ -38,50 +43,89 @@ public:
      *
      * @return HTTP response
      */
-    auto list(const app_key_t& app_key) const //
+    auto http_list(const app_key_t& app_key) const //
         -> crow::response;
-    auto list(std::string app_name, std::string version) const //
+
+    auto http_details(instance_id_t instance_id) const //
         -> crow::response;
-    auto list(std::string app_name) const //
+
+    auto http_create(app_key_t app_key, std::string instance_name) //
         -> crow::response;
-    auto list() const //
+
+    auto http_start(instance_id_t instance_id) //
         -> crow::response;
+
+    auto http_stop(instance_id_t instance_id) //
+        -> crow::response;
+
+    auto http_remove(instance_id_t instance_id) //
+        -> crow::response;
+
+    auto http_get_config(instance_id_t instance_id) const //
+        -> crow::response;
+
+    auto http_post_config(instance_id_t instance_id, const instance_config_t& config) //
+        -> crow::response;
+
+    auto http_logs(instance_id_t instance_id) const //
+        -> crow::response;
+
+    auto http_update(instance_id_t instance_id, std::string to) //
+        -> crow::response;
+
+    auto http_export_to(instance_id_t instance_id, fs::path dest_dir) const //
+        -> crow::response;
+
+    /*! @brief List all available instance ids
+     *
+     * @param app_key (optional) limit list to all or specific version of specific App
+     *
+     * @return vector containing all available instance ids
+     */
+    auto instance_ids(const app_key_t& app_key) const //
+        -> std::vector<instance_id_t>;
+    auto instance_ids(std::string app_name, std::string version) const //
+        -> std::vector<instance_id_t>;
+    auto instance_ids(std::string app_name) const //
+        -> std::vector<instance_id_t>;
+    auto instance_ids() const //
+        -> std::vector<instance_id_t>;
+
+    /*! @brief Query instance for a given instance id
+     *
+     * @param instance_id instance id to query
+     *
+     * @return shared_ptr to instance, or nullptr
+     */
+    auto query(instance_id_t instance_id) const //
+        -> std::shared_ptr<instance_t>;
+
+    /*! @brief Query if instance is running
+     *
+     * @param instance shared_ptr to instance
+     *
+     * @return true if instance is running, false otherwise
+     */
+    auto is_running(std::shared_ptr<instance_t> instance) const //
+        -> bool;
 
     auto create(app_key_t app_key, std::string instance_name) //
-        -> crow::response;
+        -> result_t;
     auto create(app_key_t app_key) //
-        -> crow::response;
+        -> result_t;
     auto create(std::string app_name, std::string version, std::string instance_name) //
-        -> crow::response;
+        -> result_t;
     auto create(std::string app_name, std::string version) //
-        -> crow::response;
+        -> result_t;
 
     auto start(instance_id_t instance_id) //
-        -> crow::response;
+        -> result_t;
 
     auto stop(instance_id_t instance_id) //
-        -> crow::response;
+        -> result_t;
 
     auto remove(instance_id_t instance_id) //
-        -> crow::response;
-
-    auto get_config(instance_id_t instance_id) const //
-        -> crow::response;
-
-    auto post_config(instance_id_t instance_id, const instance_config_t& config) //
-        -> crow::response;
-
-    auto details(instance_id_t instance_id) const //
-        -> crow::response;
-
-    auto logs(instance_id_t instance_id) const //
-        -> crow::response;
-
-    auto update(instance_id_t instance_id, std::string from, std::string to) //
-        -> crow::response;
-
-    auto export_to(instance_id_t instance_id, fs::path dest_dir) const //
-        -> crow::response;
+        -> result_t;
 
 protected:
     friend class module_factory_t;

--- a/daemon/modules/instances/src/instances.cpp
+++ b/daemon/modules/instances/src/instances.cpp
@@ -14,8 +14,8 @@
 
 #include "instances.h"
 
-#include "common/app/app_key.h"
-#include "common/instance/instance_config.h"
+#include "common/app/app.h"
+#include "common/instance/instance.h"
 #include "factory/factory.h"
 #include "impl/instances_impl.h"
 
@@ -38,36 +38,40 @@ auto module_instances_t::do_init() //
     FLECS_V2_ROUTE("/instances").methods("GET"_method)([this](const crow::request& req) {
         auto app = req.url_params.get("app");
         auto version = req.url_params.get("version");
-        return list(app ? app : "", version ? version : "");
+        return http_list(app_key_t{app ? app : "", version ? version : ""});
     });
 
     FLECS_V2_ROUTE("/instances/<string>")
-        .methods("GET"_method)(
-            [this](const std::string& instance_id) { return details(instance_id_t{instance_id}); });
+        .methods("GET"_method)([this](const std::string& instance_id) {
+            return http_details(instance_id_t{instance_id});
+        });
 
     FLECS_V2_ROUTE("/instances/create").methods("POST"_method)([this](const crow::request& req) {
         auto response = json_t{};
         const auto args = parse_json(req.body);
         REQUIRED_TYPED_JSON_VALUE(args, appKey, app_key_t);
         OPTIONAL_JSON_VALUE(args, instanceName);
-        return create(std::move(appKey), std::move(instanceName));
+        return http_create(std::move(appKey), std::move(instanceName));
     });
 
     FLECS_V2_ROUTE("/instances/<string>")
-        .methods("DELETE"_method)(
-            [this](const std::string& instance_id) { return remove(instance_id_t{instance_id}); });
+        .methods("DELETE"_method)([this](const std::string& instance_id) {
+            return http_remove(instance_id_t{instance_id});
+        });
 
     FLECS_V2_ROUTE("/instances/<string>/start")
-        .methods("POST"_method)(
-            [this](const std::string& instance_id) { return start(instance_id_t{instance_id}); });
+        .methods("POST"_method)([this](const std::string& instance_id) {
+            return http_start(instance_id_t{instance_id});
+        });
 
     FLECS_V2_ROUTE("/instances/<string>/stop")
-        .methods("POST"_method)(
-            [this](const std::string& instance_id) { return stop(instance_id_t{instance_id}); });
+        .methods("POST"_method)([this](const std::string& instance_id) {
+            return http_stop(instance_id_t{instance_id});
+        });
 
     FLECS_V2_ROUTE("/instances/<string>/config")
         .methods("GET"_method)([this](const std::string& instance_id) {
-            return get_config(instance_id_t{instance_id});
+            return http_get_config(instance_id_t{instance_id});
         });
 
     FLECS_V2_ROUTE("/instances/<string>/config")
@@ -82,125 +86,209 @@ auto module_instances_t::do_init() //
                 args["devices"]["usb"].get_to(config.usb_devices);
             }
 
-            return post_config(instance_id_t{instance_id}, config);
+            return http_post_config(instance_id_t{instance_id}, config);
         });
 
     FLECS_V2_ROUTE("/instances/<string>/logs")
-        .methods("GET"_method)(
-            [this](const std::string& instance_id) { return logs(instance_id_t{instance_id}); });
+        .methods("GET"_method)([this](const std::string& instance_id) {
+            return http_logs(instance_id_t{instance_id});
+        });
 
     FLECS_V2_ROUTE("/instances/<string>/export")
         .methods("POST"_method)([this](const std::string& instance_id) {
-            return export_to(instance_id_t{instance_id}, "/var/lib/flecs/exports/");
+            return http_export_to(instance_id_t{instance_id}, "/var/lib/flecs/exports/");
         });
 
     return _impl->do_init();
 }
 
-auto module_instances_t::list(const app_key_t& app_key) const //
+auto module_instances_t::http_list(const app_key_t& app_key) const //
     -> crow::response
 {
-    return _impl->do_list(app_key);
-}
-auto module_instances_t::list(std::string app_name, std::string version) const //
-    -> crow::response
-{
-    return list(app_key_t{std::move(app_name), std::move(version)});
-}
-auto module_instances_t::list(std::string app_name) const //
-    -> crow::response
-{
-    return list(std::move(app_name), {});
-}
-auto module_instances_t::list() const //
-    -> crow::response
-{
-    return list({}, {});
+    auto response = json_t::array();
+
+    for (const auto& instance_id : instance_ids(app_key)) {
+        auto json = json_t::object();
+
+        auto instance = query(instance_id);
+
+        json["instanceId"] = instance->id().hex();
+        json["instanceName"] = instance->instance_name();
+        if (auto app = instance->app()) {
+            json["appKey"] = app->key();
+            if (instance->status() == instance_status_e::Created) {
+                json["status"] = to_string(
+                    is_running(instance) ? instance_status_e::Running : instance_status_e::Stopped);
+            } else {
+                json["status"] = to_string(instance->status());
+            }
+        } else {
+            json["appKey"] = app_key_t{instance->app_name().data(), instance->app_version().data()};
+            json["status"] = to_string(instance_status_e::Orphaned);
+        }
+        json["desired"] = to_string(instance->desired());
+        response.push_back(std::move(json));
+    }
+
+    return {crow::status::OK, "json", response.dump()};
 }
 
-auto module_instances_t::create(
-    app_key_t app_key,
-    std::string instance_name) //
-    -> crow::response
-{
-    return _impl->queue_create(std::move(app_key), std::move(instance_name));
-}
-
-auto module_instances_t::create(app_key_t app_key) //
-    -> crow::response
-{
-    return create(std::move(app_key), {});
-}
-
-auto module_instances_t::create(
-    std::string app_name,
-    std::string version,
-    std::string instance_name) //
-    -> crow::response
-{
-    return create(app_key_t{std::move(app_name), std::move(version)}, std::move(instance_name));
-}
-
-auto module_instances_t::create(
-    std::string app_name,
-    std::string version) //
-    -> crow::response
-{
-    return create(std::move(app_name), std::move(version), {});
-}
-
-auto module_instances_t::start(instance_id_t instance_id) //
-    -> crow::response
-{
-    return _impl->queue_start(std::move(instance_id));
-}
-
-auto module_instances_t::stop(instance_id_t instance_id) //
-    -> crow::response
-{
-    return _impl->queue_stop(std::move(instance_id));
-}
-
-auto module_instances_t::remove(instance_id_t instance_id) //
-    -> crow::response
-{
-    return _impl->queue_remove(std::move(instance_id));
-}
-
-auto module_instances_t::get_config(instance_id_t instance_id) const //
-    -> crow::response
-{
-    return _impl->do_get_config(std::move(instance_id));
-}
-
-auto module_instances_t::post_config(instance_id_t instance_id, const instance_config_t& config) //
-    -> crow::response
-{
-    return _impl->do_post_config(std::move(instance_id), config);
-}
-
-auto module_instances_t::details(instance_id_t instance_id) const //
+auto module_instances_t::http_details(instance_id_t instance_id) const //
     -> crow::response
 {
     return _impl->do_details(std::move(instance_id));
 }
 
-auto module_instances_t::logs(instance_id_t instance_id) const //
+auto module_instances_t::http_create(app_key_t app_key, std::string instance_name) //
+    -> crow::response
+{
+    auto job_id = _impl->queue_create(std::move(app_key), std::move(instance_name));
+    return crow::response{
+        crow::status::ACCEPTED,
+        "json",
+        "{\"jobId\":" + std::to_string(job_id) + "}"};
+}
+
+auto module_instances_t::http_start(instance_id_t instance_id) //
+    -> crow::response
+{
+    auto job_id = _impl->queue_start(std::move(instance_id));
+    return crow::response{
+        crow::status::ACCEPTED,
+        "json",
+        "{\"jobId\":" + std::to_string(job_id) + "}"};
+}
+
+auto module_instances_t::http_stop(instance_id_t instance_id) //
+    -> crow::response
+{
+    auto job_id = _impl->queue_stop(std::move(instance_id));
+    return crow::response{
+        crow::status::ACCEPTED,
+        "json",
+        "{\"jobId\":" + std::to_string(job_id) + "}"};
+}
+
+auto module_instances_t::http_remove(instance_id_t instance_id) //
+    -> crow::response
+{
+    auto job_id = _impl->queue_remove(std::move(instance_id));
+    return crow::response{
+        crow::status::ACCEPTED,
+        "json",
+        "{\"jobId\":" + std::to_string(job_id) + "}"};
+}
+
+auto module_instances_t::http_get_config(instance_id_t instance_id) const //
+    -> crow::response
+{
+    return _impl->do_get_config(std::move(instance_id));
+}
+
+auto module_instances_t::http_post_config(
+    instance_id_t instance_id, const instance_config_t& config) //
+    -> crow::response
+{
+    return _impl->do_post_config(std::move(instance_id), config);
+}
+
+auto module_instances_t::http_logs(instance_id_t instance_id) const //
     -> crow::response
 {
     return _impl->do_logs(std::move(instance_id));
 }
 
-auto module_instances_t::update(instance_id_t instance_id, std::string from, std::string to) //
+auto module_instances_t::http_update(instance_id_t instance_id, std::string to) //
     -> crow::response
 {
-    return _impl->queue_update(std::move(instance_id), std::move(from), std::move(to));
+    auto job_id = _impl->queue_update(std::move(instance_id), std::move(to));
+    return crow::response{
+        crow::status::ACCEPTED,
+        "json",
+        "{\"jobId\":" + std::to_string(job_id) + "}"};
 }
 
-auto module_instances_t::export_to(instance_id_t instance_id, fs::path dest_dir) const //
+auto module_instances_t::http_export_to(instance_id_t instance_id, fs::path dest_dir) const //
     -> crow::response
 {
-    return _impl->queue_export_to(std::move(instance_id), std::move(dest_dir));
+    auto job_id = _impl->queue_export_to(std::move(instance_id), std::move(dest_dir));
+    return crow::response{
+        crow::status::ACCEPTED,
+        "json",
+        "{\"jobId\":" + std::to_string(job_id) + "}"};
+}
+
+auto module_instances_t::instance_ids(const app_key_t& app_key) const //
+    -> std::vector<instance_id_t>
+{
+    return _impl->do_instance_ids(app_key);
+}
+auto module_instances_t::instance_ids(std::string app_name, std::string version) const //
+    -> std::vector<instance_id_t>
+{
+    return instance_ids(app_key_t{std::move(app_name), std::move(version)});
+}
+auto module_instances_t::instance_ids(std::string app_name) const //
+    -> std::vector<instance_id_t>
+{
+    return instance_ids(app_key_t{std::move(app_name), {}});
+}
+auto module_instances_t::instance_ids() const //
+    -> std::vector<instance_id_t>
+{
+    return instance_ids(app_key_t{});
+}
+
+auto module_instances_t::query(instance_id_t instance_id) const //
+    -> std::shared_ptr<instance_t>
+{
+    return _impl->do_query(std::move(instance_id));
+}
+
+auto module_instances_t::is_running(std::shared_ptr<instance_t> instance) const //
+    -> bool
+{
+    return _impl->do_is_running(std::move(instance));
+}
+
+auto module_instances_t::create(app_key_t app_key, std::string instance_name) //
+    -> result_t
+{
+    return _impl->do_create_sync(std::move(app_key), std::move(instance_name));
+}
+auto module_instances_t::create(app_key_t app_key) //
+    -> result_t
+{
+    return create(std::move(app_key), {});
+}
+auto module_instances_t::create(
+    std::string app_name, std::string version, std::string instance_name) //
+    -> result_t
+{
+    return create(app_key_t{std::move(app_name), std::move(version)}, std::move(instance_name));
+}
+auto module_instances_t::create(std::string app_name, std::string version) //
+    -> result_t
+{
+    return create(app_key_t{std::move(app_name), std::move(version)}, {});
+}
+
+auto module_instances_t::start(instance_id_t instance_id) //
+    -> result_t
+{
+    return _impl->do_start_sync(std::move(instance_id));
+}
+
+auto module_instances_t::stop(instance_id_t instance_id) //
+    -> result_t
+{
+    return _impl->do_stop_sync(std::move(instance_id));
+}
+
+auto module_instances_t::remove(instance_id_t instance_id) //
+    -> result_t
+{
+    return _impl->do_remove_sync(std::move(instance_id));
 }
 
 } // namespace FLECS

--- a/daemon/modules/jobs/job_progress.h
+++ b/daemon/modules/jobs/job_progress.h
@@ -18,6 +18,7 @@
 #include <mutex>
 #include <string>
 
+#include "core/flecs.h"
 #include "job_id.h"
 #include "job_status.h"
 #include "util/json/json.h"
@@ -53,17 +54,6 @@ public:
             , _units_total{}
             , _units_done{}
             , _rate{}
-        {}
-    };
-
-    struct result_t
-    {
-        std::int32_t code;
-        std::string message;
-
-        result_t()
-            : code{}
-            , message{}
         {}
     };
 

--- a/daemon/modules/jobs/src/impl/jobs_impl.cpp
+++ b/daemon/modules/jobs/src/impl/jobs_impl.cpp
@@ -103,7 +103,7 @@ auto module_jobs_t::do_wait_for_job(job_id_t job_id) const //
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
     } while (true);
 
-    return {0, {}};
+    return it->result();
 }
 
 auto module_jobs_t::fetch_job() //

--- a/daemon/modules/jobs/src/job_progress.cpp
+++ b/daemon/modules/jobs/src/job_progress.cpp
@@ -114,8 +114,7 @@ auto job_progress_t::result(std::int32_t code, std::string message) //
     -> void
 {
     auto _ = lock();
-    _result.code = std::move(code);
-    _result.message = std::move(message);
+    _result = result_t{std::move(code), std::move(message)};
 }
 
 auto to_json(json_t& j, const job_progress_t& progress) //
@@ -136,8 +135,8 @@ auto to_json(json_t& j, const job_progress_t& progress) //
     j["currentStep"]["unitsDone"] = progress._current_step._units_done;
     j["currentStep"]["rate"] = progress._current_step._rate;
     j["result"] = json_t::object();
-    j["result"]["code"] = progress._result.code;
-    j["result"]["message"] = progress._result.message;
+    j["result"]["code"] = std::get<0>(progress._result);
+    j["result"]["message"] = std::get<1>(progress._result);
 }
 
 auto operator<(const job_progress_t& lhs, const job_progress_t& rhs) //

--- a/daemon/modules/jobs/test/test_jobs.cpp
+++ b/daemon/modules/jobs/test/test_jobs.cpp
@@ -136,7 +136,7 @@ TEST(jobs, status)
     }
     {
         const auto [res, message] = uut.wait_for_job(2);
-        ASSERT_EQ(res, 0);
+        ASSERT_EQ(res, -1);
         ASSERT_TRUE(job_1.executed);
     }
 


### PR DESCRIPTION
When calling interface functions from other modules, having only an http interface means additional overhead and non-intuitive use. Therefore the main interface is designed for use from within FLECS, while small wrapper functions provide http functionality on top.