### PR TITLE
build: run git version detection through sudo

### DIFF
--- a/.github/workflows/develop.workflow.yml
+++ b/.github/workflows/develop.workflow.yml
@@ -19,6 +19,7 @@ jobs:
           submodules: recursive
       - name: "CMake: Configure"
         run: |
+          git config --system --add safe.directory "*"
           cmake -G Ninja -B out/${{ matrix.arch }} -DARCH=${{ matrix.arch }}
       - name: "CMake: Build"
         run: |

--- a/.github/workflows/pull-request.workflow.yml
+++ b/.github/workflows/pull-request.workflow.yml
@@ -19,6 +19,7 @@ jobs:
           submodules: recursive
       - name: "CMake: Configure"
         run: |
+          git config --system --add safe.directory "*"
           cmake -G Ninja -B out/${{ matrix.arch }} -DARCH=${{ matrix.arch }}
       - name: "CMake: Build"
         run: |
@@ -41,6 +42,7 @@ jobs:
           submodules: recursive
       - name: "CMake: Configure"
         run: |
+          git config --system --add safe.directory "*"
           cmake -G Ninja -B out/${{ matrix.arch }} -DARCH=${{ matrix.arch }} -DFLECS_BUILD_TESTS=Yes
       - name: "CMake: Build"
         run: |

--- a/.github/workflows/release.workflow.yml
+++ b/.github/workflows/release.workflow.yml
@@ -20,6 +20,7 @@ jobs:
           submodules: recursive
       - name: "CMake: Configure"
         run: |
+          git config --system --add safe.directory "*"
           cmake -G Ninja -B out/${{ matrix.arch }} -DARCH=${{ matrix.arch }} -DCMAKE_BUILD_TYPE=Release -DNDEBUG=1
       - name: "CMake: Build"
         run: |

--- a/daemon/modules/version/CMakeLists.txt
+++ b/daemon/modules/version/CMakeLists.txt
@@ -17,10 +17,24 @@ flecs_add_module(
 )
 
 execute_process(
-    COMMAND git -C ${CMAKE_SOURCE_DIR} rev-parse --short HEAD
+    COMMAND stat -c "%u" ${CMAKE_SOURCE_DIR}/.git
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    OUTPUT_VARIABLE FLECS_GIT_UID
+    ERROR_VARIABLE FLECS_GIT_UID_ERROR
+)
+if ("${FLECS_GIT_UID}" STREQUAL "")
+    message(FATAL_ERROR ${FLECS_GIT_UID_ERROR})
+endif()
+
+execute_process(
+    COMMAND sudo -u \#${FLECS_GIT_UID} git -C ${CMAKE_SOURCE_DIR} rev-parse --short HEAD
     OUTPUT_STRIP_TRAILING_WHITESPACE
     OUTPUT_VARIABLE FLECS_GIT_SHA
+    ERROR_VARIABLE FLECS_GIT_SHA_ERROR
 )
+if (NOT FLECS_GIT_SHA)
+    message(FATAL_ERROR ${FLECS_GIT_SHA_ERROR})
+endif()
 
 target_compile_definitions(FLECS.daemon.modules.version PUBLIC
     -DFLECS_GIT_SHA="${FLECS_GIT_SHA}"


### PR DESCRIPTION
Git 2.35.2 introduced new security measures, which prohibit execution of git commands in a repository owned by another user. It is therefore no longer possible to generate the GIT_SHA appended to our software version. As a solution, detect the owner of the root .git directory und use sudo to run the GIT_SHA generation as this user.