### PR TITLE
deployment: fix removal of instances of other app versions upon uninstall

### DIFF
--- a/daemon/common/deployment/deployment.h
+++ b/daemon/common/deployment/deployment.h
@@ -44,11 +44,6 @@ public:
         network_type_e type;
     };
 
-    enum version_filter_e {
-        MatchVersion = 0,
-        AllVersions = 1,
-    };
-
     deployment_t() = default;
 
     virtual ~deployment_t() = default;
@@ -61,8 +56,7 @@ public:
     auto save(const fs::path& base_path = "/var/lib/flecs/") //
         -> result_t;
 
-    auto instance_ids(
-        const app_key_t& app_key, version_filter_e version_filter = AllVersions) const //
+    auto instance_ids(const app_key_t& app_key) const //
         -> std::vector<instance_id_t>;
     auto instance_ids(std::string_view app, std::string_view version) const //
         -> std::vector<instance_id_t>;

--- a/daemon/common/deployment/src/deployment.cpp
+++ b/daemon/common/deployment/src/deployment.cpp
@@ -48,29 +48,28 @@ auto deployment_t::save(const fs::path& base_path) //
 auto deployment_t::instance_ids() const //
     -> std::vector<instance_id_t>
 {
-    return instance_ids(app_key_t{}, AllVersions);
+    return instance_ids(app_key_t{});
 }
 
 auto deployment_t::instance_ids(std::string_view app) const //
     -> std::vector<instance_id_t>
 {
-    return instance_ids(app_key_t{app.data(), ""}, AllVersions);
+    return instance_ids(app_key_t{app.data(), ""});
 }
 
 auto deployment_t::instance_ids(std::string_view app, std::string_view version) const //
     -> std::vector<instance_id_t>
 {
-    return instance_ids(app_key_t{app.data(), version.data()}, MatchVersion);
+    return instance_ids(app_key_t{app.data(), version.data()});
 }
 
-auto deployment_t::instance_ids(const app_key_t& app_key, version_filter_e version_filter) const //
+auto deployment_t::instance_ids(const app_key_t& app_key) const //
     -> std::vector<instance_id_t>
 {
     auto ids = std::vector<instance_id_t>{};
     for (const auto& instance : _instances) {
         const auto apps_match = app_key.name().empty() || (app_key.name() == instance->app_name());
         const auto versions_match = app_key.name().empty() || app_key.version().empty() ||
-                                    version_filter == AllVersions ||
                                     (app_key.version() == instance->app_version());
         if (apps_match && versions_match) {
             ids.emplace_back(instance->id());

--- a/daemon/modules/instances/src/impl/instances_impl.cpp
+++ b/daemon/modules/instances/src/impl/instances_impl.cpp
@@ -191,7 +191,7 @@ auto module_instances_t::do_create(
 
     // Step 3: Ensure there is only one instance of single-instance apps
     if (!manifest->multi_instance()) {
-        const auto instance_ids = _deployment->instance_ids(app->key(), deployment_t::MatchVersion);
+        const auto instance_ids = _deployment->instance_ids(app->key());
         if (!instance_ids.empty()) {
             auto instance = _deployment->query_instance(instance_ids.front());
             instance->app(std::move(app));


### PR DESCRIPTION
When uninstalling an App, instances of another version might be removed in the process. This is caused by some pre-app_key code, which used explicit version filters instead of partial app_key's for filtering.

Remove explicit version_filters and rely on partial app_key's instead.