### PR TITLE
apps: add multiInstance and editor to App list

### DIFF
--- a/daemon/modules/apps/impl/apps_impl.h
+++ b/daemon/modules/apps/impl/apps_impl.h
@@ -53,9 +53,6 @@ private:
     auto do_app_keys(const app_key_t& app_key) const //
         -> std::vector<app_key_t>;
 
-    auto do_list(const app_key_t& app_key) const //
-        -> crow::response;
-
     auto queue_install_from_marketplace(app_key_t app_key, std::string license_key) //
         -> job_id_t;
     auto do_install_from_marketplace_sync(

--- a/daemon/modules/apps/src/apps.cpp
+++ b/daemon/modules/apps/src/apps.cpp
@@ -14,6 +14,7 @@
 
 #include "apps.h"
 
+#include "common/app/manifest/manifest.h"
 #include "factory/factory.h"
 #include "impl/apps_impl.h"
 #include "util/datetime/datetime.h"
@@ -93,6 +94,15 @@ auto module_apps_t::http_list(const app_key_t& app_key) const //
         auto app = query(key);
         if (app) {
             response.push_back(*app);
+            /** @todo this should be done some other way */
+            auto& val = *response.rbegin();
+            if (auto manifest = app->manifest()) {
+                val["multiInstance"] = manifest->multi_instance();
+                val["editor"] = manifest->editor();
+            } else {
+                val["multiInstance"] = false;
+                val["editor"] = std::string{};
+            }
         }
     }
 

--- a/daemon/modules/apps/src/impl/apps_impl.cpp
+++ b/daemon/modules/apps/src/impl/apps_impl.cpp
@@ -200,23 +200,6 @@ auto module_apps_t::do_app_keys(const app_key_t& app_key) const //
     return res;
 }
 
-auto module_apps_t::do_list(const app_key_t& app_key) const //
-    -> crow::response
-{
-    auto response = json_t::array();
-
-    for (decltype(auto) app : _apps) {
-        const auto apps_match = app_key.name().empty() || (app_key.name() == app->key().name());
-        const auto versions_match = app_key.name().empty() || app_key.version().empty() ||
-                                    (app_key.version() == app->key().version());
-        if (apps_match && versions_match) {
-            response.push_back(*app);
-        }
-    }
-
-    return {crow::status::OK, "json", response.dump()};
-}
-
 auto module_apps_t::queue_install_from_marketplace(app_key_t app_key, std::string license_key) //
     -> job_id_t
 {


### PR DESCRIPTION
The WebApp needs additional information about installed Apps to display optional buttons conditionally. This information would be available through other APIs, though they require increased effort on the WebApp side. For now, we fall back to providing this information in the /apps route directly and focus on a better approach at a later time.