### PR TITLE
flecsport: export/import all Instance details

### DIFF
--- a/daemon/common/deployment/src/deployment.cpp
+++ b/daemon/common/deployment/src/deployment.cpp
@@ -607,12 +607,13 @@ auto deployment_t::import_config_file(
     std::shared_ptr<instance_t> instance, const conffile_t& config_file, fs::path base_dir) //
     -> result_t
 {
-    const auto conf_path = "/var/lib/flecs/instances/" + instance->id().hex() + "/conf/";
+    const auto conf_dir = fs::path{"/var/lib/flecs/instances/"} / instance->id().hex() / "conf";
     /* copy config files from local dir for stopped instances */
     auto ec = std::error_code{};
+    fs::create_directories(conf_dir, ec);
     fs::copy(
-        conf_path + config_file.local(),
-        base_dir / "conf" / config_file.local(),
+        base_dir / config_file.local(),
+        conf_dir / config_file.local(),
         fs::copy_options::overwrite_existing,
         ec);
     if (ec) {

--- a/daemon/modules/flecsport/export_manifest.h
+++ b/daemon/modules/flecsport/export_manifest.h
@@ -18,7 +18,7 @@
 #include <vector>
 
 #include "common/app/app_key.h"
-#include "common/instance/instance_id.h"
+#include "common/instance/instance.h"
 #include "util/json/json.h"
 #include "util/sysinfo/sysinfo.h"
 
@@ -34,16 +34,7 @@ struct export_manifest_t
     struct
     {
         std::vector<app_key_t> apps;
-        struct instance
-        {
-            instance(instance_id_t instance_id, app_key_t app_key)
-                : instance_id{std::move(instance_id)}
-                , app_key(std::move(app_key))
-            {}
-            instance_id_t instance_id;
-            app_key_t app_key;
-        };
-        std::vector<instance> instances;
+        std::vector<instance_t> instances;
     } contents;
 
     // device info

--- a/daemon/modules/flecsport/src/export_manifest.cpp
+++ b/daemon/modules/flecsport/src/export_manifest.cpp
@@ -45,10 +45,7 @@ auto to_json(json_t& j, const export_manifest_t& export_manifest) //
     j["_schemaVersion"] = "2.0.0";
     j["time"] = export_manifest.time;
     j["contents"]["apps"] = export_manifest.contents.apps;
-    for (const auto& i : export_manifest.contents.instances) {
-        auto instance_json = json_t({{"instanceId", i.instance_id.hex()}, {"appKey", i.app_key}});
-        j["contents"]["instances"].push_back(std::move(instance_json));
-    }
+    j["contents"]["instances"] = export_manifest.contents.instances;
     j["device"]["sysinfo"] = export_manifest.device.sysinfo;
     j["device"]["hostname"] = export_manifest.device.hostname;
     j["version"]["core"] = export_manifest.version.core;
@@ -61,11 +58,7 @@ auto from_json(const json_t& j, export_manifest_t& export_manifest) //
     try {
         j.at("time").get_to(export_manifest.time);
         j.at("contents").at("apps").get_to(export_manifest.contents.apps);
-        for (const auto& i : j.at("contents").at("instances")) {
-            export_manifest.contents.instances.emplace_back(
-                i.get<instance_id_t>(),
-                i.at("appKey").get<app_key_t>());
-        }
+        j.at("contents").at("instances").get_to(export_manifest.contents.instances);
         j.at("device").at("sysinfo").get_to(export_manifest.device.sysinfo);
         j.at("device").at("hostname").get_to(export_manifest.device.hostname);
         j.at("version").at("core").get_to(export_manifest.version.core);

--- a/daemon/modules/instances/impl/instances_impl.h
+++ b/daemon/modules/instances/impl/instances_impl.h
@@ -111,15 +111,11 @@ private:
     auto do_export_to(instance_id_t instance_id, fs::path base_path, job_progress_t& progress) //
         -> result_t;
 
-    auto queue_import_from(instance_id_t instance_id, app_key_t app_key, fs::path base_path) //
+    auto queue_import_from(instance_t instance, fs::path base_path) //
         -> job_id_t;
-    auto do_import_from_sync(instance_id_t instance_id, app_key_t app_key, fs::path base_path) //
+    auto do_import_from_sync(instance_t instance, fs::path base_path) //
         -> result_t;
-    auto do_import_from(
-        instance_id_t instance_id,
-        app_key_t app_key,
-        fs::path base_path,
-        job_progress_t& progress) //
+    auto do_import_from(instance_t instance, fs::path base_path, job_progress_t& progress) //
         -> result_t;
 
     FLECS::module_instances_t* _parent;

--- a/daemon/modules/instances/instances.h
+++ b/daemon/modules/instances/instances.h
@@ -134,7 +134,7 @@ public:
     auto export_to(instance_id_t instance_id, fs::path base_path) const //
         -> result_t;
 
-    auto import_from(instance_id_t instance_id, app_key_t app_key, fs::path base_path) //
+    auto import_from(instance_t instance, fs::path base_path) //
         -> result_t;
 
 protected:

--- a/daemon/modules/instances/src/instances.cpp
+++ b/daemon/modules/instances/src/instances.cpp
@@ -316,14 +316,10 @@ auto module_instances_t::export_to(instance_id_t instance_id, fs::path base_path
     return _impl->do_export_to_sync(std::move(instance_id), std::move(base_path));
 }
 
-auto module_instances_t::import_from(
-    instance_id_t instance_id, app_key_t app_key, fs::path base_path) //
+auto module_instances_t::import_from(instance_t instance, fs::path base_path) //
     -> result_t
 {
-    return _impl->do_import_from_sync(
-        std::move(instance_id),
-        std::move(app_key),
-        std::move(base_path));
+    return _impl->do_import_from_sync(std::move(instance), std::move(base_path));
 }
 
 } // namespace FLECS


### PR DESCRIPTION
Some additional information about Instances should be preserved when exporting and importing Instances. Among these are Instance names, IP addresses and their specific configuration. Therefore, export full Instances instead of only their metadata to restore their full representation on import.