### PR TITLE
manifest: allow dashes in environment variable names

### DIFF
--- a/daemon/common/app/manifest/env_var/src/env_var.cpp
+++ b/daemon/common/app/manifest/env_var/src/env_var.cpp
@@ -27,7 +27,7 @@ env_var_t::env_var_t(std::string var)
 auto env_var_t::is_valid() const noexcept //
     -> bool
 {
-    const auto name_regex = std::regex{"^[a-zA-Z]+(?:[a-zA-Z0-9_]|[\\.][a-zA-Z0-9_])*$"};
+    const auto name_regex = std::regex{"^[a-zA-Z]+(?:[a-zA-Z0-9_\\-\\.])*$"};
 
     if (std::regex_match(_var, name_regex)) {
         return true;

--- a/daemon/common/app/manifest/env_var/test/test_env_var.cpp
+++ b/daemon/common/app/manifest/env_var/test/test_env_var.cpp
@@ -24,11 +24,14 @@ TEST(env_var, valid)
     auto env_var1 = FLECS::env_var_t{"VALID_ENV_VAR1"};
     auto env_var2 = FLECS::env_var_t{"valid_env_var"};
     auto env_var3 = FLECS::env_var_t{"V1_"};
-    auto env_var4 = FLECS::env_var_t{"Valid.Env.Var"};
+    auto env_var4 = FLECS::env_var_t{"valid-env-var"};
+    auto env_var5 = FLECS::env_var_t{"valid.env_var-2"};
 
     ASSERT_TRUE(env_var1.is_valid());
     ASSERT_TRUE(env_var2.is_valid());
     ASSERT_TRUE(env_var3.is_valid());
+    ASSERT_TRUE(env_var4.is_valid());
+    ASSERT_TRUE(env_var5.is_valid());
 }
 
 TEST(env_var, invalid)
@@ -36,14 +39,10 @@ TEST(env_var, invalid)
     auto env_var1 = FLECS::env_var_t{"_INVALID_ENV_VAR1"};
     auto env_var2 = FLECS::env_var_t{"INVALID ENV VAR"};
     auto env_var3 = FLECS::env_var_t{"1Invalid"};
-    auto env_var4 = FLECS::env_var_t{"Invalid.Env.Var."};
-    auto env_var5 = FLECS::env_var_t{"Invalid..Env.Var."};
 
     ASSERT_FALSE(env_var1.is_valid());
     ASSERT_FALSE(env_var2.is_valid());
     ASSERT_FALSE(env_var3.is_valid());
-    ASSERT_FALSE(env_var4.is_valid());
-    ASSERT_FALSE(env_var5.is_valid());
 }
 
 TEST(env_var, mapped_valid)
@@ -51,13 +50,15 @@ TEST(env_var, mapped_valid)
     auto mapped_env_var1 = FLECS::mapped_env_var_t("VALID_ENV_VAR"s, "VALUE"s);
     auto mapped_env_var2 = FLECS::mapped_env_var_t("VALID_ENV_VAR"s, "VALUE"s);
     auto mapped_env_var3 = FLECS::mapped_env_var_t("VALID_ENV_VAR"s, "ANOTHER_VALUE"s);
-    auto another_mapped_env_var1 = FLECS::mapped_env_var_t("ANOTHER_VALID_ENV_VAR"s, "VALUE"s);
+    auto mapped_env_var4 = FLECS::mapped_env_var_t("another.valid-env_var.2"s, "some special! value?"s);
 
     ASSERT_TRUE(mapped_env_var1.is_valid());
     ASSERT_EQ(FLECS::stringify(mapped_env_var1), "VALID_ENV_VAR=VALUE");
     ASSERT_EQ(mapped_env_var1, mapped_env_var2);
     ASSERT_EQ(mapped_env_var1, mapped_env_var3);
-    ASSERT_NE(mapped_env_var1, another_mapped_env_var1);
+    ASSERT_NE(mapped_env_var1, mapped_env_var4);
+    ASSERT_TRUE(mapped_env_var4.is_valid());
+    ASSERT_EQ(FLECS::stringify(mapped_env_var4), "another.valid-env_var.2=some special! value?");
 }
 
 TEST(env_var, mapped_invalid_1)

--- a/daemon/common/app/manifest/test/test_app_manifest.cpp
+++ b/daemon/common/app/manifest/test/test_app_manifest.cpp
@@ -62,11 +62,20 @@ private:
 #define G_DEVICES         \
     G_YAML_KEY("devices") \
     G_YAML_INDENT G_YAML_ITEM(G_DEVICE)
-#define G_ENV_VAR_KEY "MY_ENV_VAR"
-#define G_ENV_VAR_VALUE "ENV_VAR_VALUE"
+#define G_ENV_VAR1_KEY "MY_ENV_VAR"
+#define G_ENV_VAR1_VALUE "ENV_VAR_VALUE"
+#define G_ENV_VAR2_KEY "my.other.env"
+#define G_ENV_VAR2_VALUE "MY_OTHER_VALUE"
+#define G_ENV_VAR3_KEY "my.env.with.spaces"
+#define G_ENV_VAR3_VALUE "Value with spaces"
+#define G_ENV_VAR4_KEY "my-env-with-dashes"
+#define G_ENV_VAR4_VALUE "value-with-dashes"
 #define G_ENVS        \
     G_YAML_KEY("env") \
-    G_YAML_INDENT G_YAML_MAPPING(G_ENV_VAR_KEY, G_ENV_VAR_VALUE)
+    G_YAML_INDENT G_YAML_MAPPING(G_ENV_VAR1_KEY, G_ENV_VAR1_VALUE) \
+    G_YAML_INDENT G_YAML_MAPPING(G_ENV_VAR2_KEY, G_ENV_VAR2_VALUE) \
+    G_YAML_INDENT G_YAML_MAPPING(G_ENV_VAR3_KEY, G_ENV_VAR3_VALUE) \
+    G_YAML_INDENT G_YAML_MAPPING(G_ENV_VAR4_KEY, G_ENV_VAR4_VALUE)
 #define G_IMAGE "flecs/test-app"
 #define G_NETWORK_SETTINGS_KEY_1 "macAddress"
 #define G_NETWORK_SETTINGS_VALUE_1 "clone:eth0"
@@ -167,7 +176,10 @@ TEST(daemon_app, complex_app)
     ASSERT_EQ(app.interactive(), true);
     ASSERT_EQ(
         (*app.env().cbegin()),
-        (FLECS::mapped_env_var_t{FLECS::env_var_t{G_ENV_VAR_KEY}, G_ENV_VAR_VALUE}));
+        (FLECS::mapped_env_var_t{FLECS::env_var_t{G_ENV_VAR1_KEY}, G_ENV_VAR1_VALUE}));
+    ASSERT_EQ(
+        (*(++app.env().cbegin())),
+        (FLECS::mapped_env_var_t{FLECS::env_var_t{G_ENV_VAR4_KEY}, G_ENV_VAR4_VALUE}));
     ASSERT_EQ(
         (std::find_if(
              app.volumes().cbegin(),
@@ -234,7 +246,7 @@ TEST(daemon_app, to_json)
         R"-("capabilities":[],)-"
         R"-("conffiles":["local.conf:/etc/container.conf:rw,no_init"],)-"
         R"-("devices":["/dev/device0"],)-"
-        R"-("env":["MY_ENV_VAR=ENV_VAR_VALUE"],)-"
+        R"-("env":["MY_ENV_VAR=ENV_VAR_VALUE","my-env-with-dashes=value-with-dashes","my.env.with.spaces=Value with spaces","my.other.env=MY_OTHER_VALUE"],)-"
         R"-("hostname":"flecs-unit-test",)-"
         R"-("interactive":true,)-"
         R"-("networks":[{"mac_address":"","name":"flecs","parent":"","type":"bridge"}],)-"


### PR DESCRIPTION
Dashes should have been allowed in the first place following FLX-333. Somehow they were forgotten, so here goes...