### PR TITLE
Update submodule flecs-build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,16 +59,3 @@ include(flecs-rules)
 add_custom_command(TARGET packages POST_BUILD
     COMMAND echo -n ${CORE_VERSION} >${CMAKE_INSTALL_PREFIX}/latest_flecs_${ARCH}
 )
-
-if (NOT TARGET coverage)
-    add_custom_target(
-        coverage
-        DEPENDS test
-        COMMAND mkdir -p coverage
-        COMMAND gcovr -r ${CMAKE_SOURCE_DIR} -e ${CMAKE_SOURCE_DIR}/examples/ -e ${CMAKE_SOURCE_DIR}/external/ -e ${CMAKE_BINARY_DIR} --html-details coverage/coverage.html
-    )
-endif()
-
-add_custom_target(version
-    COMMAND echo "${CORE_VERSION}"
-)

--- a/daemon/api/lib/test/CMakeLists.txt
+++ b/daemon/api/lib/test/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if (BUILD_TESTING)
+if (FLECS_BUILD_TESTS)
     project(daemon.api.lib.test)
 
     add_executable(daemon.api.lib.test

--- a/daemon/api/test/CMakeLists.txt
+++ b/daemon/api/test/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if(BUILD_TESTING)
+if(FLECS_BUILD_TESTS)
     set(PROJECT_NAME daemon.api.test)
     project(${PROJECT_NAME})
 

--- a/daemon/common/app/manifest/conffile/test/CMakeLists.txt
+++ b/daemon/common/app/manifest/conffile/test/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if (BUILD_TESTING)
+if (FLECS_BUILD_TESTS)
     project(daemon.app.conffile.test)
 
     add_executable(daemon.app.conffile.test

--- a/daemon/common/app/manifest/env_var/test/CMakeLists.txt
+++ b/daemon/common/app/manifest/env_var/test/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if (BUILD_TESTING)
+if (FLECS_BUILD_TESTS)
     project(daemon.app.env_var.test)
 
     add_executable(daemon.app.env_var.test

--- a/daemon/common/app/manifest/port_range/test/CMakeLists.txt
+++ b/daemon/common/app/manifest/port_range/test/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if (BUILD_TESTING)
+if (FLECS_BUILD_TESTS)
     project(daemon.app.port_range.test)
 
     add_executable(daemon.app.port_range.test

--- a/daemon/common/app/manifest/startup_option/test/CMakeLists.txt
+++ b/daemon/common/app/manifest/startup_option/test/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if(BUILD_TESTING)
+if(FLECS_BUILD_TESTS)
     project(daemon.app.startup_option.test)
 
     add_executable(daemon.app.startup_option.test

--- a/daemon/common/app/manifest/test/CMakeLists.txt
+++ b/daemon/common/app/manifest/test/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if (BUILD_TESTING)
+if (FLECS_BUILD_TESTS)
     set(PROJECT_NAME daemon.common.app.manifest.test)
     project(${PROJECT_NAME})
 

--- a/daemon/common/app/manifest/volume/test/CMakeLists.txt
+++ b/daemon/common/app/manifest/volume/test/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if (BUILD_TESTING)
+if (FLECS_BUILD_TESTS)
     set(PROJECT_NAME daemon.common.app.manifest.volume.test)
 
     project(${PROJECT_NAME})

--- a/daemon/common/deployment/test/CMakeLists.txt
+++ b/daemon/common/deployment/test/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if(BUILD_TESTING)
+if(FLECS_BUILD_TESTS)
     project(daemon.deployment.test)
 
     add_executable(daemon.deployment.test

--- a/daemon/common/network/test/CMakeLists.txt
+++ b/daemon/common/network/test/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if(BUILD_TESTING)
+if(FLECS_BUILD_TESTS)
     set(PROJECT_NAME daemon.common.network.test)
     project(${PROJECT_NAME})
 

--- a/daemon/modules/apps/test/CMakeLists.txt
+++ b/daemon/modules/apps/test/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if(BUILD_TESTING)
+if(FLECS_BUILD_TESTS)
     project(modules.apps.test)
 
     add_executable(${PROJECT_NAME}

--- a/daemon/modules/console/test/CMakeLists.txt
+++ b/daemon/modules/console/test/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if(BUILD_TESTING)
+if(FLECS_BUILD_TESTS)
     project(daemon.modules.console.test)
 
     add_executable(daemon.modules.console.test

--- a/daemon/modules/device/test/CMakeLists.txt
+++ b/daemon/modules/device/test/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if(BUILD_TESTING)
+if(FLECS_BUILD_TESTS)
     set(PROJECT_NAME daemon.modules.device.test)
     project(${PROJECT_NAME})
 

--- a/daemon/modules/instances/test/CMakeLists.txt
+++ b/daemon/modules/instances/test/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if(BUILD_TESTING)
+if(FLECS_BUILD_TESTS)
     project(modules.instances.test)
 
     add_executable(${PROJECT_NAME}

--- a/daemon/modules/jobs/test/CMakeLists.txt
+++ b/daemon/modules/jobs/test/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if(BUILD_TESTING)
+if(FLECS_BUILD_TESTS)
     set(PROJECT_NAME daemon.modules.jobs.test)
     project(${PROJECT_NAME})
 

--- a/daemon/modules/manifests/test/CMakeLists.txt
+++ b/daemon/modules/manifests/test/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if(BUILD_TESTING)
+if(FLECS_BUILD_TESTS)
     set(PROJECT_NAME daemon.modules.manifests.test)
     project(${PROJECT_NAME})
 

--- a/daemon/modules/system/test/CMakeLists.txt
+++ b/daemon/modules/system/test/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if (BUILD_TESTING)
+if (FLECS_BUILD_TESTS)
     project(daemon.modules.system.test)
 
     add_executable(daemon.modules.system.test

--- a/daemon/modules/version/test/CMakeLists.txt
+++ b/daemon/modules/version/test/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if(BUILD_TESTING)
+if(FLECS_BUILD_TESTS)
     project(daemon.modules.version.test)
 
     add_executable(daemon.modules.version.test

--- a/util/archive/test/CMakeLists.txt
+++ b/util/archive/test/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if(BUILD_TESTING)
+if(FLECS_BUILD_TESTS)
     project(util.archive.test)
 
     add_executable(${PROJECT_NAME}

--- a/util/cxx23/test/CMakeLists.txt
+++ b/util/cxx23/test/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if(BUILD_TESTING)
+if(FLECS_BUILD_TESTS)
     project(util.cxx20.test)
 
     add_executable(util.cxx20.test

--- a/util/datetime/test/CMakeLists.txt
+++ b/util/datetime/test/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if (BUILD_TESTING)
+if (FLECS_BUILD_TESTS)
     project(util.datetime.test)
 
     add_executable(util.datetime.test

--- a/util/network/test/CMakeLists.txt
+++ b/util/network/test/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if(BUILD_TESTING)
+if(FLECS_BUILD_TESTS)
     project(util.network.test)
 
     add_executable(test.util.network

--- a/util/process/test/CMakeLists.txt
+++ b/util/process/test/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if (BUILD_TESTING)
+if (FLECS_BUILD_TESTS)
     project(util.process.test)
 
     add_executable(test.util.process

--- a/util/random/test/CMakeLists.txt
+++ b/util/random/test/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if(BUILD_TESTING)
+if(FLECS_BUILD_TESTS)
     set(PROJECT_NAME util.random.test)
     project(${PROJECT_NAME})
 

--- a/util/signal_handler/test/CMakeLists.txt
+++ b/util/signal_handler/test/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if(BUILD_TESTING)
+if(FLECS_BUILD_TESTS)
     project(util.signal_handler.test)
 
     add_executable(util.signal_handler.test

--- a/util/string/test/CMakeLists.txt
+++ b/util/string/test/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if(BUILD_TESTING)
+if(FLECS_BUILD_TESTS)
     project(util.string.utils.test)
 
     add_executable(${PROJECT_NAME}

--- a/util/sysfs/test/CMakeLists.txt
+++ b/util/sysfs/test/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if(BUILD_TESTING)
+if(FLECS_BUILD_TESTS)
     set(PROJECT_NAME util.sysfs.test)
     project(${PROJECT_NAME})
 

--- a/util/udev/test/CMakeLists.txt
+++ b/util/udev/test/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if(BUILD_TESTING)
+if(FLECS_BUILD_TESTS)
     set(PROJECT_NAME util.udev.test)
     project(${PROJECT_NAME})
 

--- a/util/usb/test/CMakeLists.txt
+++ b/util/usb/test/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if(BUILD_TESTING)
+if(FLECS_BUILD_TESTS)
     set(PROJECT_NAME util.usb.test)
     project(${PROJECT_NAME})
 


### PR DESCRIPTION
- Outsources target 'coverage'
- Fixes building of unit tests