### PR TITLE
gem::instance::docker: Allow failing instance restart during export

### DIFF
--- a/flecs-core/src/jeweler/gem/instance/docker/mod.rs
+++ b/flecs-core/src/jeweler/gem/instance/docker/mod.rs
@@ -1043,7 +1043,12 @@ impl DockerInstance {
         .await;
         let export_volumes_result = join_all(export_volumes_results).await;
         if is_running {
-            self.start(floxy).await?;
+            if let Err(e) = self.start(floxy).await {
+                error!(
+                    "Failed to restart instance {} after exporting config files and volumes: {e}",
+                    self.id
+                );
+            }
         }
         export_config_files_result?;
         for result in export_volumes_result {


### PR DESCRIPTION
Log error if instance can not be restarted during export instead of returning the error