### PR TITLE
FLX-1075: Editor port can not be opened after restarting instance

### DIFF
--- a/flecs-core/src/fsm/world/mod.rs
+++ b/flecs-core/src/fsm/world/mod.rs
@@ -246,14 +246,14 @@ impl<
             .await
             .shutdown_with(|quest| async move {
                 instancius
-                    .halt_all_instances(quest, vault, FloxyOperation::new_arc(floxy))
+                    .shutdown_instances(quest, vault, FloxyOperation::new_arc(floxy))
                     .await?;
                 Ok(QuestResult::None)
             })
             .await
         {
             Ok(Ok(_)) => {}
-            Ok(Err(e)) => error!("Failed to halt all instances: {e}"),
+            Ok(Err(e)) => error!("Failed to shutdown instances: {e}"),
             Err(e) => error!("Failed to shutdown QuestMaster: {e}"),
         }
         match self.enchantments.floxy.stop() {

--- a/flecs-core/src/jeweler/gem/instance/compose/mod.rs
+++ b/flecs-core/src/jeweler/gem/instance/compose/mod.rs
@@ -140,6 +140,10 @@ impl InstanceCommon for ComposeInstance {
         }
         Ok(())
     }
+
+    async fn halt(&self) -> anyhow::Result<()> {
+        ComposeInstance::halt(self).await
+    }
 }
 
 impl ComposeInstance {

--- a/flecs-core/src/jeweler/gem/instance/mod.rs
+++ b/flecs-core/src/jeweler/gem/instance/mod.rs
@@ -84,6 +84,7 @@ pub trait InstanceCommon {
     fn taken_ipv4_addresses(&self) -> Vec<Ipv4Addr>;
     async fn logs(&self) -> anyhow::Result<Logs>;
     async fn import(&mut self, quest: SyncQuest, src: PathBuf, dst: PathBuf) -> anyhow::Result<()>;
+    async fn halt(&self) -> anyhow::Result<()>;
 }
 
 impl Deref for Instance {

--- a/flecs-core/src/sorcerer/instancius/mod.rs
+++ b/flecs-core/src/sorcerer/instancius/mod.rs
@@ -178,7 +178,16 @@ pub trait Instancius: Sorcerer {
         vault: Arc<Vault>,
     ) -> Vec<flecsd_axum_server::models::AppInstance>;
 
-    async fn halt_all_instances<F: Floxy + 'static>(
+    async fn halt_all_instances(&self, quest: SyncQuest, vault: Arc<Vault>) -> Result<()>;
+
+    async fn shutdown_instances<F: Floxy + 'static>(
+        &self,
+        quest: SyncQuest,
+        vault: Arc<Vault>,
+        floxy: Arc<FloxyOperation<F>>,
+    ) -> Result<()>;
+
+    async fn delete_floxy_server_configs<F: Floxy + 'static>(
         &self,
         quest: SyncQuest,
         vault: Arc<Vault>,


### PR DESCRIPTION
instance::docker: Clear mapped ports on deleting floxy server configs
instance::docker: Delete floxy server configs only on stop
world: Delete floxy server configs